### PR TITLE
Add Docker Compose setup for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+# Multi-Agent Portfolio Advisor - Environment Variables
+# Copy this file to .env and fill in the values
+#
+# To generate secure random values:
+#   openssl rand -hex 32
+
+# =============================================================================
+# PostgreSQL Configuration
+# =============================================================================
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=changeme_postgres_password
+
+# =============================================================================
+# Redis Configuration
+# =============================================================================
+REDIS_PASSWORD=changeme_redis_password
+
+# =============================================================================
+# ClickHouse Configuration (for Langfuse analytics)
+# =============================================================================
+CLICKHOUSE_USER=default
+CLICKHOUSE_PASSWORD=changeme_clickhouse_password
+
+# =============================================================================
+# MinIO Configuration (S3-compatible storage for Langfuse)
+# =============================================================================
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=changeme_minio_password
+
+# =============================================================================
+# Langfuse Security Configuration
+# Generate these with: openssl rand -hex 32
+# =============================================================================
+NEXTAUTH_SECRET=changeme_generate_with_openssl_rand_hex_32
+ENCRYPTION_KEY=changeme_generate_with_openssl_rand_hex_32
+ENCRYPTION_SALT=changeme_generate_with_openssl_rand_hex_32
+
+# =============================================================================
+# Application Configuration (for future use)
+# =============================================================================
+# ANTHROPIC_API_KEY=your_anthropic_api_key
+# LANGFUSE_PUBLIC_KEY=your_langfuse_public_key
+# LANGFUSE_SECRET_KEY=your_langfuse_secret_key
+# LANGFUSE_HOST=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+# Environment files (contain secrets)
+.env
+.env.local
+.env.*.local
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+.venv/
+venv/
+ENV/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Testing
+.coverage
+.pytest_cache/
+htmlcov/
+
+# mypy
+.mypy_cache/
+
+# ruff
+.ruff_cache/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,220 @@
+# Multi-Agent Portfolio Advisor - Docker Compose
+# Issue #2: Infrastructure Setup
+#
+# Usage:
+#   Start:    docker compose up -d
+#   Stop:     docker compose down
+#   Logs:     docker compose logs -f [service]
+#   Reset:    docker compose down -v (removes volumes)
+
+services:
+  # =============================================================================
+  # PostgreSQL - Shared database for Langfuse and Portfolio Advisor
+  # =============================================================================
+  postgres:
+    image: postgres:15-alpine
+    container_name: portfolio-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # =============================================================================
+  # Redis - Caching and queue for both Langfuse and Portfolio Advisor
+  # =============================================================================
+  redis:
+    image: redis:7-alpine
+    container_name: portfolio-redis
+    restart: unless-stopped
+    command: redis-server --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required} --appendonly yes
+    volumes:
+      - redis_data:/data
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # =============================================================================
+  # ClickHouse - Analytics database for Langfuse traces
+  # =============================================================================
+  clickhouse:
+    image: clickhouse/clickhouse-server:24-alpine
+    container_name: portfolio-clickhouse
+    restart: unless-stopped
+    environment:
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-default}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD is required}
+      CLICKHOUSE_DB: langfuse
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+      - clickhouse_logs:/var/log/clickhouse-server
+    ports:
+      - "127.0.0.1:8123:8123"  # HTTP interface (localhost only)
+      - "127.0.0.1:9000:9000"  # Native interface (localhost only)
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --user ${CLICKHOUSE_USER:-default} --password ${CLICKHOUSE_PASSWORD} --query 'SELECT 1'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+
+  # =============================================================================
+  # MinIO - S3-compatible object storage for Langfuse
+  # =============================================================================
+  minio:
+    image: minio/minio:latest
+    container_name: portfolio-minio
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
+    volumes:
+      - minio_data:/data
+    ports:
+      - "127.0.0.1:9090:9000"  # API (localhost only for internal use)
+      - "127.0.0.1:9001:9001"  # Console (localhost only)
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # =============================================================================
+  # Langfuse Web - UI and API
+  # =============================================================================
+  langfuse-web:
+    image: langfuse/langfuse:latest
+    container_name: portfolio-langfuse-web
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    environment:
+      # Database
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/langfuse
+
+      # ClickHouse
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-default}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+
+      # Redis
+      REDIS_CONNECTION_STRING: redis://:${REDIS_PASSWORD}@redis:6379/0
+
+      # S3/MinIO
+      LANGFUSE_S3_EVENT_UPLOAD_ENABLED: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: us-east-1
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: ${MINIO_ROOT_USER:-minioadmin}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+
+      # Security
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}
+      NEXTAUTH_URL: http://localhost:3000
+      SALT: ${ENCRYPTION_SALT:?ENCRYPTION_SALT is required}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY is required}
+
+      # Server
+      NODE_ENV: production
+      HOSTNAME: 0.0.0.0
+      PORT: 3000
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:3000/api/public/health || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  # =============================================================================
+  # Langfuse Worker - Background job processing
+  # =============================================================================
+  langfuse-worker:
+    image: langfuse/langfuse-worker:latest
+    container_name: portfolio-langfuse-worker
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    environment:
+      # Database
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/langfuse
+
+      # ClickHouse
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-default}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+
+      # Redis
+      REDIS_CONNECTION_STRING: redis://:${REDIS_PASSWORD}@redis:6379/0
+
+      # S3/MinIO
+      LANGFUSE_S3_EVENT_UPLOAD_ENABLED: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: us-east-1
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: ${MINIO_ROOT_USER:-minioadmin}
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+
+      # Security
+      SALT: ${ENCRYPTION_SALT}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+
+      # Server
+      NODE_ENV: production
+      PORT: 3030
+    ports:
+      - "127.0.0.1:3030:3030"  # localhost only
+
+# =============================================================================
+# Volumes
+# =============================================================================
+volumes:
+  postgres_data:
+    name: portfolio-postgres-data
+  redis_data:
+    name: portfolio-redis-data
+  clickhouse_data:
+    name: portfolio-clickhouse-data
+  clickhouse_logs:
+    name: portfolio-clickhouse-logs
+  minio_data:
+    name: portfolio-minio-data

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,0 +1,16 @@
+-- Multi-Agent Portfolio Advisor - PostgreSQL Initialization
+-- This script runs once when the PostgreSQL container is first created.
+-- It creates separate databases for Langfuse and the Portfolio Advisor application.
+
+-- Create database for Langfuse observability platform
+CREATE DATABASE langfuse;
+
+-- Create database for Portfolio Advisor application state
+CREATE DATABASE portfolio_advisor;
+
+-- Grant privileges (using the default postgres user)
+GRANT ALL PRIVILEGES ON DATABASE langfuse TO postgres;
+GRANT ALL PRIVILEGES ON DATABASE portfolio_advisor TO postgres;
+
+-- Log completion
+\echo 'Databases created: langfuse, portfolio_advisor'


### PR DESCRIPTION
## Summary

- Configure PostgreSQL 15 with two databases (`langfuse` for observability, `portfolio_advisor` for app state)
- Set up Redis 7 with persistence for caching and queues
- Add ClickHouse for Langfuse analytics traces
- Configure MinIO as S3-compatible object storage for Langfuse
- Deploy self-hosted Langfuse (web + worker) with full observability

## Services & Ports

| Service | Port | Description |
|---------|------|-------------|
| PostgreSQL | 5432 | Main database |
| Redis | 6379 | Cache/queue |
| Langfuse UI | 3000 | Observability dashboard |
| ClickHouse | 8123/9000 | Analytics (localhost only) |
| MinIO Console | 9001 | Object storage (localhost only) |

## Usage

```bash
# Copy and configure environment
cp .env.example .env
# Generate secure values:
# openssl rand -hex 32

# Start all services
docker compose up -d

# Verify
curl http://localhost:3000/api/public/health

# Stop
docker compose down
```

## Test Plan

- [x] `docker compose up` starts all services
- [x] All health checks pass
- [x] Langfuse UI accessible at localhost:3000
- [x] PostgreSQL connectable at localhost:5432
- [x] Redis connectable at localhost:6379
- [x] Both databases created (langfuse, portfolio_advisor)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)