### PR TITLE
Add base agent class with LangGraph integration

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -5,3 +5,7 @@ This module contains specialized agents:
 - AnalysisAgent: Analyzes portfolio risk and performance
 - RecommendationAgent: Generates trade recommendations
 """
+
+from src.agents.base import AgentState, BaseAgent
+
+__all__ = ["AgentState", "BaseAgent"]

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -1,0 +1,186 @@
+"""Base agent class for all specialized agents.
+
+This module provides the abstract base class that all agents inherit from,
+integrated with Anthropic Claude and LangGraph for state management.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+import structlog
+from anthropic import Anthropic
+from pydantic import BaseModel, ConfigDict
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+class AgentState(BaseModel):
+    """Base state for agent workflows.
+
+    This state is passed between agents in the workflow and accumulates
+    results from each step.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    messages: list[dict[str, Any]] = []
+    context: dict[str, Any] = {}
+    errors: list[str] = []
+
+
+class BaseAgent(ABC):
+    """Abstract base class for all agents.
+
+    Provides common functionality for LLM interaction, state management,
+    and error handling. All specialized agents must inherit from this class.
+
+    Attributes:
+        llm: Anthropic client for Claude API calls
+        model: Model identifier to use for completions
+        max_tokens: Maximum tokens for LLM responses
+    """
+
+    def __init__(
+        self,
+        llm: Anthropic | None = None,
+        model: str = "claude-sonnet-4-20250514",
+        max_tokens: int = 4096,
+    ) -> None:
+        """Initialize the base agent.
+
+        Args:
+            llm: Optional Anthropic client. If not provided, creates a new one.
+            model: Model to use for completions.
+            max_tokens: Maximum tokens for responses.
+        """
+        self.llm = llm or Anthropic()
+        self.model = model
+        self.max_tokens = max_tokens
+        self._logger = logger.bind(agent=self.name)
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the agent's unique name."""
+        ...
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Return a description of what this agent does."""
+        ...
+
+    @property
+    @abstractmethod
+    def system_prompt(self) -> str:
+        """Return the system prompt for this agent."""
+        ...
+
+    @property
+    def tools(self) -> list[dict[str, Any]]:
+        """Return the list of tools available to this agent.
+
+        Override in subclasses to provide agent-specific tools.
+        """
+        return []
+
+    @retry(
+        retry=retry_if_exception_type((TimeoutError, ConnectionError)),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        reraise=True,
+    )
+    async def _call_llm(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Make a retry-enabled call to the LLM.
+
+        Args:
+            messages: List of message dicts with role and content.
+            tools: Optional list of tool definitions.
+
+        Returns:
+            The LLM response as a dict.
+
+        Raises:
+            TimeoutError: If the request times out after retries.
+            ConnectionError: If connection fails after retries.
+        """
+        self._logger.debug(
+            "calling_llm",
+            message_count=len(messages),
+            has_tools=bool(tools),
+        )
+
+        # Build request parameters
+        params: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "system": self.system_prompt,
+            "messages": messages,
+        }
+
+        if tools:
+            params["tools"] = tools
+
+        response = self.llm.messages.create(**params)
+
+        self._logger.debug(
+            "llm_response_received",
+            stop_reason=response.stop_reason,
+            usage={"input": response.usage.input_tokens, "output": response.usage.output_tokens},
+        )
+
+        return {
+            "role": "assistant",
+            "content": [block.model_dump() for block in response.content],
+            "stop_reason": response.stop_reason,
+            "usage": {
+                "input_tokens": response.usage.input_tokens,
+                "output_tokens": response.usage.output_tokens,
+            },
+        }
+
+    @abstractmethod
+    async def invoke(self, state: AgentState) -> AgentState:
+        """Process the current state and return updated state.
+
+        This is the main entry point for agent execution. Subclasses must
+        implement this method to define their specific behavior.
+
+        Args:
+            state: The current workflow state.
+
+        Returns:
+            The updated state after processing.
+        """
+        ...
+
+    async def __call__(self, state: AgentState) -> AgentState:
+        """Allow agent to be called as a function.
+
+        This enables using the agent directly in LangGraph workflows.
+
+        Args:
+            state: The current workflow state.
+
+        Returns:
+            The updated state after processing.
+        """
+        self._logger.info("agent_invoked", state_keys=list(state.context.keys()))
+        try:
+            result = await self.invoke(state)
+            self._logger.info("agent_completed", success=True)
+            return result
+        except Exception as e:
+            self._logger.error("agent_failed", error=str(e))
+            state.errors.append(f"{self.name}: {e!s}")
+            return state

--- a/tests/test_agents/test_base.py
+++ b/tests/test_agents/test_base.py
@@ -1,0 +1,196 @@
+"""Tests for the base agent class."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.agents.base import AgentState, BaseAgent
+
+
+class ConcreteAgent(BaseAgent):
+    """Concrete implementation of BaseAgent for testing."""
+
+    @property
+    def name(self) -> str:
+        return "test_agent"
+
+    @property
+    def description(self) -> str:
+        return "A test agent for unit testing"
+
+    @property
+    def system_prompt(self) -> str:
+        return "You are a test agent."
+
+    async def invoke(self, state: AgentState) -> AgentState:
+        """Simple implementation that adds a message."""
+        state.messages.append({"role": "assistant", "content": "Test response"})
+        state.context["processed"] = True
+        return state
+
+
+class TestAgentState:
+    """Tests for AgentState model."""
+
+    def test_default_values(self) -> None:
+        """Test that AgentState has correct defaults."""
+        state = AgentState()
+        assert state.messages == []
+        assert state.context == {}
+        assert state.errors == []
+
+    def test_with_values(self) -> None:
+        """Test AgentState with custom values."""
+        state = AgentState(
+            messages=[{"role": "user", "content": "Hello"}],
+            context={"key": "value"},
+            errors=["error1"],
+        )
+        assert len(state.messages) == 1
+        assert state.context["key"] == "value"
+        assert len(state.errors) == 1
+
+    def test_extra_fields_allowed(self) -> None:
+        """Test that extra fields are allowed in AgentState."""
+        state = AgentState(custom_field="custom_value")  # type: ignore[call-arg]
+        assert state.custom_field == "custom_value"  # type: ignore[attr-defined]
+
+
+class TestBaseAgent:
+    """Tests for BaseAgent abstract class."""
+
+    def test_cannot_instantiate_base_agent(self) -> None:
+        """Test that BaseAgent cannot be instantiated directly."""
+        with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+            BaseAgent()  # type: ignore[abstract]
+
+    def test_concrete_agent_instantiation(self) -> None:
+        """Test that concrete implementations can be instantiated."""
+        agent = ConcreteAgent()
+        assert agent.name == "test_agent"
+        assert agent.description == "A test agent for unit testing"
+        assert agent.system_prompt == "You are a test agent."
+        assert agent.tools == []
+
+    def test_custom_llm_client(self) -> None:
+        """Test that a custom LLM client can be provided."""
+        mock_llm = MagicMock()
+        agent = ConcreteAgent(llm=mock_llm)
+        assert agent.llm is mock_llm
+
+    def test_custom_model_and_tokens(self) -> None:
+        """Test custom model and max_tokens configuration."""
+        agent = ConcreteAgent(model="claude-3-opus-20240229", max_tokens=8192)
+        assert agent.model == "claude-3-opus-20240229"
+        assert agent.max_tokens == 8192
+
+    @pytest.mark.asyncio
+    async def test_invoke(self) -> None:
+        """Test the invoke method."""
+        agent = ConcreteAgent()
+        state = AgentState()
+
+        result = await agent.invoke(state)
+
+        assert len(result.messages) == 1
+        assert result.messages[0]["content"] == "Test response"
+        assert result.context["processed"] is True
+
+    @pytest.mark.asyncio
+    async def test_call_method(self) -> None:
+        """Test that agent can be called as a function."""
+        agent = ConcreteAgent()
+        state = AgentState()
+
+        result = await agent(state)
+
+        assert result.context["processed"] is True
+
+    @pytest.mark.asyncio
+    async def test_call_handles_errors(self) -> None:
+        """Test that __call__ handles errors gracefully."""
+
+        class FailingAgent(BaseAgent):
+            @property
+            def name(self) -> str:
+                return "failing_agent"
+
+            @property
+            def description(self) -> str:
+                return "Agent that fails"
+
+            @property
+            def system_prompt(self) -> str:
+                return "You are a failing agent."
+
+            async def invoke(self, state: AgentState) -> AgentState:  # noqa: ARG002
+                raise ValueError("Intentional failure")
+
+        agent = FailingAgent()
+        state = AgentState()
+
+        result = await agent(state)
+
+        assert len(result.errors) == 1
+        assert "failing_agent: Intentional failure" in result.errors[0]
+
+    @pytest.mark.asyncio
+    async def test_call_llm(self) -> None:
+        """Test the _call_llm method."""
+        mock_response = MagicMock()
+        mock_response.stop_reason = "end_turn"
+        mock_response.usage.input_tokens = 10
+        mock_response.usage.output_tokens = 20
+        mock_content = MagicMock()
+        mock_content.model_dump.return_value = {"type": "text", "text": "Hello"}
+        mock_response.content = [mock_content]
+
+        mock_llm = MagicMock()
+        mock_llm.messages.create.return_value = mock_response
+
+        agent = ConcreteAgent(llm=mock_llm)
+        messages: list[dict[str, Any]] = [{"role": "user", "content": "Hi"}]
+
+        result = await agent._call_llm(messages)
+
+        assert result["role"] == "assistant"
+        assert result["stop_reason"] == "end_turn"
+        assert result["usage"]["input_tokens"] == 10
+        assert result["usage"]["output_tokens"] == 20
+
+        mock_llm.messages.create.assert_called_once_with(
+            model="claude-sonnet-4-20250514",
+            max_tokens=4096,
+            system="You are a test agent.",
+            messages=messages,
+        )
+
+    @pytest.mark.asyncio
+    async def test_call_llm_with_tools(self) -> None:
+        """Test _call_llm includes tools when provided."""
+        mock_response = MagicMock()
+        mock_response.stop_reason = "tool_use"
+        mock_response.usage.input_tokens = 15
+        mock_response.usage.output_tokens = 25
+        mock_content = MagicMock()
+        mock_content.model_dump.return_value = {"type": "tool_use", "name": "test_tool"}
+        mock_response.content = [mock_content]
+
+        mock_llm = MagicMock()
+        mock_llm.messages.create.return_value = mock_response
+
+        agent = ConcreteAgent(llm=mock_llm)
+        messages: list[dict[str, Any]] = [{"role": "user", "content": "Use a tool"}]
+        tools: list[dict[str, Any]] = [{"name": "test_tool", "description": "A test tool"}]
+
+        result = await agent._call_llm(messages, tools=tools)
+
+        assert result["stop_reason"] == "tool_use"
+        mock_llm.messages.create.assert_called_once_with(
+            model="claude-sonnet-4-20250514",
+            max_tokens=4096,
+            system="You are a test agent.",
+            messages=messages,
+            tools=tools,
+        )


### PR DESCRIPTION
## Summary

- Creates `BaseAgent` abstract class that all specialized agents will inherit from
- Implements `AgentState` Pydantic model for workflow state management
- Integrates with Anthropic Claude API via the `anthropic` SDK
- Adds retry logic using `tenacity` for transient failures (timeout, connection errors)
- Includes structured logging with `structlog` for observability

## Key Features

### BaseAgent Class
- Abstract properties: `name`, `description`, `system_prompt`
- Optional `tools` property for agent-specific tools
- `_call_llm()` method with retry decorator for reliable LLM calls
- `invoke()` abstract method for agent-specific logic
- `__call__()` for LangGraph workflow compatibility with error handling

### AgentState Model
- `messages`: List of conversation messages
- `context`: Dict for passing data between agents
- `errors`: List for tracking errors during workflow
- Allows extra fields for flexibility

## Test plan

- [x] Test AgentState model validation and defaults
- [x] Test BaseAgent cannot be instantiated directly
- [x] Test concrete implementations work correctly
- [x] Test custom LLM client injection
- [x] Test LLM call with and without tools
- [x] Test error handling in __call__
- [x] Run ruff linting - passes
- [x] Run mypy type checking - passes
- [x] All 13 tests pass

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)