### PR TITLE
Add Langfuse tracing integration

### DIFF
--- a/src/observability/__init__.py
+++ b/src/observability/__init__.py
@@ -6,3 +6,23 @@ This module contains:
 - Cost attribution
 - Dashboard utilities
 """
+
+from src.observability.tracing import (
+    TraceContext,
+    flush_traces,
+    get_langfuse_client,
+    shutdown_tracing,
+    traced_agent,
+    traced_generation,
+    traced_tool,
+)
+
+__all__ = [
+    "TraceContext",
+    "flush_traces",
+    "get_langfuse_client",
+    "shutdown_tracing",
+    "traced_agent",
+    "traced_generation",
+    "traced_tool",
+]

--- a/src/observability/tracing.py
+++ b/src/observability/tracing.py
@@ -1,0 +1,343 @@
+"""Langfuse tracing integration for observability.
+
+This module provides tracing capabilities using Langfuse for comprehensive
+observability of agent workflows, LLM calls, and tool executions.
+
+Span Hierarchy:
+- Session: Top-level grouping for user sessions
+- Request: Individual API requests within a session
+- Agent: Agent execution spans
+- Tool: Tool/function call spans
+- Generation: LLM API calls
+"""
+
+import os
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, ParamSpec, TypeVar
+
+import structlog
+from langfuse import Langfuse, get_client, propagate_attributes
+from langfuse import observe as langfuse_observe
+
+logger = structlog.get_logger(__name__)
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def get_langfuse_client() -> Langfuse:
+    """Get or create the Langfuse client.
+
+    Uses environment variables for configuration:
+    - LANGFUSE_PUBLIC_KEY: Public API key
+    - LANGFUSE_SECRET_KEY: Secret API key
+    - LANGFUSE_HOST: Host URL (default: http://localhost:3000)
+
+    Returns:
+        Configured Langfuse client instance.
+    """
+    host = os.getenv("LANGFUSE_HOST", "http://localhost:3000")
+    public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
+    secret_key = os.getenv("LANGFUSE_SECRET_KEY")
+
+    if public_key and secret_key:
+        return Langfuse(
+            public_key=public_key,
+            secret_key=secret_key,
+            host=host,
+        )
+
+    # Fall back to get_client which uses env vars automatically
+    return get_client()
+
+
+def traced_agent(
+    name: str,
+    *,
+    capture_input: bool = True,
+    capture_output: bool = True,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Decorator for tracing agent execution.
+
+    Creates a span for the agent with proper metadata and nesting.
+
+    Args:
+        name: Name of the agent for the trace.
+        capture_input: Whether to capture function inputs.
+        capture_output: Whether to capture function outputs.
+
+    Returns:
+        Decorated function with tracing.
+
+    Example:
+        @traced_agent("research_agent")
+        async def research(state: AgentState) -> AgentState:
+            ...
+    """
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        @wraps(func)
+        @langfuse_observe(
+            name=name,
+            as_type="span",
+            capture_input=capture_input,
+            capture_output=capture_output,
+        )
+        async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            logger.debug("agent_trace_start", agent=name)
+            result: R = await func(*args, **kwargs)  # type: ignore[misc]
+            logger.debug("agent_trace_end", agent=name)
+            return result
+
+        @wraps(func)
+        @langfuse_observe(
+            name=name,
+            as_type="span",
+            capture_input=capture_input,
+            capture_output=capture_output,
+        )
+        def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            logger.debug("agent_trace_start", agent=name)
+            result: R = func(*args, **kwargs)
+            logger.debug("agent_trace_end", agent=name)
+            return result
+
+        # Return appropriate wrapper based on function type
+        import asyncio
+
+        if asyncio.iscoroutinefunction(func):
+            return async_wrapper  # type: ignore[return-value]
+        return sync_wrapper
+
+    return decorator
+
+
+def traced_tool(
+    name: str,
+    *,
+    capture_input: bool = True,
+    capture_output: bool = True,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Decorator for tracing tool execution.
+
+    Creates a tool-type span for function calls.
+
+    Args:
+        name: Name of the tool for the trace.
+        capture_input: Whether to capture function inputs.
+        capture_output: Whether to capture function outputs.
+
+    Returns:
+        Decorated function with tracing.
+
+    Example:
+        @traced_tool("market_data")
+        async def get_market_data(symbol: str) -> dict:
+            ...
+    """
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        @wraps(func)
+        @langfuse_observe(
+            name=name,
+            as_type="tool",
+            capture_input=capture_input,
+            capture_output=capture_output,
+        )
+        async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            logger.debug("tool_trace_start", tool=name)
+            result: R = await func(*args, **kwargs)  # type: ignore[misc]
+            logger.debug("tool_trace_end", tool=name)
+            return result
+
+        @wraps(func)
+        @langfuse_observe(
+            name=name,
+            as_type="tool",
+            capture_input=capture_input,
+            capture_output=capture_output,
+        )
+        def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            logger.debug("tool_trace_start", tool=name)
+            result: R = func(*args, **kwargs)
+            logger.debug("tool_trace_end", tool=name)
+            return result
+
+        import asyncio
+
+        if asyncio.iscoroutinefunction(func):
+            return async_wrapper  # type: ignore[return-value]
+        return sync_wrapper
+
+    return decorator
+
+
+def traced_generation(
+    name: str,
+    *,
+    model: str | None = None,
+    capture_input: bool = True,
+    capture_output: bool = True,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Decorator for tracing LLM generation calls.
+
+    Creates a generation-type span for LLM API calls.
+
+    Args:
+        name: Name of the generation for the trace.
+        model: Model name to record in the trace.
+        capture_input: Whether to capture function inputs.
+        capture_output: Whether to capture function outputs.
+
+    Returns:
+        Decorated function with tracing.
+
+    Example:
+        @traced_generation("analyze_portfolio", model="claude-sonnet-4-20250514")
+        async def analyze(prompt: str) -> str:
+            ...
+    """
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        @wraps(func)
+        @langfuse_observe(
+            name=name,
+            as_type="generation",
+            capture_input=capture_input,
+            capture_output=capture_output,
+        )
+        async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            logger.debug("generation_trace_start", name=name, model=model)
+            result: R = await func(*args, **kwargs)  # type: ignore[misc]
+            logger.debug("generation_trace_end", name=name)
+            return result
+
+        @wraps(func)
+        @langfuse_observe(
+            name=name,
+            as_type="generation",
+            capture_input=capture_input,
+            capture_output=capture_output,
+        )
+        def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            logger.debug("generation_trace_start", name=name, model=model)
+            result: R = func(*args, **kwargs)
+            logger.debug("generation_trace_end", name=name)
+            return result
+
+        import asyncio
+
+        if asyncio.iscoroutinefunction(func):
+            return async_wrapper  # type: ignore[return-value]
+        return sync_wrapper
+
+    return decorator
+
+
+class TraceContext:
+    """Context manager for creating trace sessions.
+
+    Provides a way to group related operations under a common session
+    with propagated attributes.
+
+    Example:
+        async with TraceContext(
+            session_id="user-123",
+            user_id="user-123",
+            metadata={"request_type": "portfolio_analysis"}
+        ):
+            result = await agent(state)
+    """
+
+    def __init__(
+        self,
+        session_id: str | None = None,
+        user_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        tags: list[str] | None = None,
+    ) -> None:
+        """Initialize trace context.
+
+        Args:
+            session_id: Optional session identifier for grouping traces.
+            user_id: Optional user identifier.
+            metadata: Optional metadata dict to attach to traces.
+            tags: Optional list of tags.
+        """
+        self.session_id = session_id
+        self.user_id = user_id
+        self.metadata = metadata or {}
+        self.tags = tags or []
+        self._context_manager: Any = None
+
+    async def __aenter__(self) -> "TraceContext":
+        """Enter async context and start trace session."""
+        self._context_manager = propagate_attributes(
+            session_id=self.session_id,
+            user_id=self.user_id,
+            metadata=self.metadata,
+            tags=self.tags,
+        )
+        self._context_manager.__enter__()
+        logger.debug(
+            "trace_context_started",
+            session_id=self.session_id,
+            user_id=self.user_id,
+        )
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit async context and end trace session."""
+        if self._context_manager:
+            self._context_manager.__exit__(exc_type, exc_val, exc_tb)
+        logger.debug("trace_context_ended", session_id=self.session_id)
+
+    def __enter__(self) -> "TraceContext":
+        """Enter sync context and start trace session."""
+        self._context_manager = propagate_attributes(
+            session_id=self.session_id,
+            user_id=self.user_id,
+            metadata=self.metadata,
+            tags=self.tags,
+        )
+        self._context_manager.__enter__()
+        logger.debug(
+            "trace_context_started",
+            session_id=self.session_id,
+            user_id=self.user_id,
+        )
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit sync context and end trace session."""
+        if self._context_manager:
+            self._context_manager.__exit__(exc_type, exc_val, exc_tb)
+        logger.debug("trace_context_ended", session_id=self.session_id)
+
+
+def flush_traces() -> None:
+    """Flush any pending traces to Langfuse.
+
+    Call this in short-lived processes (scripts, serverless) to ensure
+    all traces are sent before the process exits.
+    """
+    try:
+        client = get_client()
+        client.flush()
+        logger.debug("traces_flushed")
+    except Exception as e:
+        logger.warning("flush_traces_failed", error=str(e))
+
+
+def shutdown_tracing() -> None:
+    """Gracefully shutdown tracing with final flush.
+
+    Call this before process exit to ensure all data is sent.
+    """
+    try:
+        client = get_client()
+        client.shutdown()
+        logger.debug("tracing_shutdown")
+    except Exception as e:
+        logger.warning("shutdown_tracing_failed", error=str(e))

--- a/tests/test_observability/__init__.py
+++ b/tests/test_observability/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for observability module."""

--- a/tests/test_observability/test_tracing.py
+++ b/tests/test_observability/test_tracing.py
@@ -1,0 +1,213 @@
+"""Tests for Langfuse tracing integration."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.observability.tracing import (
+    TraceContext,
+    flush_traces,
+    get_langfuse_client,
+    shutdown_tracing,
+    traced_agent,
+    traced_generation,
+    traced_tool,
+)
+
+
+class TestGetLangfuseClient:
+    """Tests for get_langfuse_client function."""
+
+    @patch.dict(
+        os.environ,
+        {
+            "LANGFUSE_PUBLIC_KEY": "pk-test",
+            "LANGFUSE_SECRET_KEY": "sk-test",
+            "LANGFUSE_HOST": "http://localhost:3000",
+        },
+    )
+    @patch("src.observability.tracing.Langfuse")
+    def test_creates_client_with_env_vars(self, mock_langfuse: MagicMock) -> None:
+        """Test client creation with environment variables."""
+        get_langfuse_client()
+
+        mock_langfuse.assert_called_once_with(
+            public_key="pk-test",
+            secret_key="sk-test",
+            host="http://localhost:3000",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("src.observability.tracing.get_client")
+    def test_falls_back_to_get_client(self, mock_get_client: MagicMock) -> None:
+        """Test fallback to get_client when env vars not set."""
+        # Clear the env vars that might exist
+        for key in ["LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST"]:
+            os.environ.pop(key, None)
+
+        get_langfuse_client()
+
+        mock_get_client.assert_called_once()
+
+
+class TestTracedAgentDecorator:
+    """Tests for traced_agent decorator."""
+
+    @pytest.mark.asyncio
+    async def test_async_function_decorated(self) -> None:
+        """Test that async functions are properly decorated."""
+
+        @traced_agent("test_agent")
+        async def my_agent(value: int) -> int:
+            return value * 2
+
+        result = await my_agent(5)
+        assert result == 10
+
+    def test_sync_function_decorated(self) -> None:
+        """Test that sync functions are properly decorated."""
+
+        @traced_agent("test_agent")
+        def my_agent(value: int) -> int:
+            return value * 2
+
+        result = my_agent(5)
+        assert result == 10
+
+    @pytest.mark.asyncio
+    async def test_preserves_function_metadata(self) -> None:
+        """Test that function metadata is preserved."""
+
+        @traced_agent("test_agent")
+        async def my_agent(value: int) -> int:
+            """My agent docstring."""
+            return value
+
+        assert my_agent.__name__ == "my_agent"
+        assert my_agent.__doc__ == "My agent docstring."
+
+
+class TestTracedToolDecorator:
+    """Tests for traced_tool decorator."""
+
+    @pytest.mark.asyncio
+    async def test_async_tool_decorated(self) -> None:
+        """Test that async tools are properly decorated."""
+
+        @traced_tool("market_data")
+        async def get_data(symbol: str) -> dict[str, str]:
+            return {"symbol": symbol}
+
+        result = await get_data("AAPL")
+        assert result == {"symbol": "AAPL"}
+
+    def test_sync_tool_decorated(self) -> None:
+        """Test that sync tools are properly decorated."""
+
+        @traced_tool("market_data")
+        def get_data(symbol: str) -> dict[str, str]:
+            return {"symbol": symbol}
+
+        result = get_data("AAPL")
+        assert result == {"symbol": "AAPL"}
+
+
+class TestTracedGenerationDecorator:
+    """Tests for traced_generation decorator."""
+
+    @pytest.mark.asyncio
+    async def test_async_generation_decorated(self) -> None:
+        """Test that async generations are properly decorated."""
+
+        @traced_generation("llm_call", model="claude-sonnet-4-20250514")
+        async def call_llm(prompt: str) -> str:
+            return f"Response to: {prompt}"
+
+        result = await call_llm("Hello")
+        assert result == "Response to: Hello"
+
+    def test_sync_generation_decorated(self) -> None:
+        """Test that sync generations are properly decorated."""
+
+        @traced_generation("llm_call")
+        def call_llm(prompt: str) -> str:
+            return f"Response to: {prompt}"
+
+        result = call_llm("Hello")
+        assert result == "Response to: Hello"
+
+
+class TestTraceContext:
+    """Tests for TraceContext context manager."""
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager(self) -> None:
+        """Test TraceContext as async context manager."""
+        async with TraceContext(
+            session_id="test-session",
+            user_id="test-user",
+            metadata={"key": "value"},
+            tags=["test"],
+        ) as ctx:
+            assert ctx.session_id == "test-session"
+            assert ctx.user_id == "test-user"
+            assert ctx.metadata == {"key": "value"}
+            assert ctx.tags == ["test"]
+
+    def test_sync_context_manager(self) -> None:
+        """Test TraceContext as sync context manager."""
+        with TraceContext(
+            session_id="test-session",
+            user_id="test-user",
+        ) as ctx:
+            assert ctx.session_id == "test-session"
+            assert ctx.user_id == "test-user"
+
+    def test_default_values(self) -> None:
+        """Test TraceContext with default values."""
+        ctx = TraceContext()
+        assert ctx.session_id is None
+        assert ctx.user_id is None
+        assert ctx.metadata == {}
+        assert ctx.tags == []
+
+
+class TestFlushAndShutdown:
+    """Tests for flush and shutdown functions."""
+
+    @patch("src.observability.tracing.get_client")
+    def test_flush_traces(self, mock_get_client: MagicMock) -> None:
+        """Test flush_traces calls client.flush()."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        flush_traces()
+
+        mock_client.flush.assert_called_once()
+
+    @patch("src.observability.tracing.get_client")
+    def test_flush_traces_handles_error(self, mock_get_client: MagicMock) -> None:
+        """Test flush_traces handles errors gracefully."""
+        mock_get_client.side_effect = Exception("Connection error")
+
+        # Should not raise
+        flush_traces()
+
+    @patch("src.observability.tracing.get_client")
+    def test_shutdown_tracing(self, mock_get_client: MagicMock) -> None:
+        """Test shutdown_tracing calls client.shutdown()."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        shutdown_tracing()
+
+        mock_client.shutdown.assert_called_once()
+
+    @patch("src.observability.tracing.get_client")
+    def test_shutdown_tracing_handles_error(self, mock_get_client: MagicMock) -> None:
+        """Test shutdown_tracing handles errors gracefully."""
+        mock_get_client.side_effect = Exception("Connection error")
+
+        # Should not raise
+        shutdown_tracing()


### PR DESCRIPTION
## Summary

- Implements comprehensive observability using Langfuse for tracing agent workflows
- Creates decorators for automatic span creation: `traced_agent`, `traced_tool`, `traced_generation`
- Provides `TraceContext` for session/request grouping with attribute propagation
- Supports both async and sync functions
- Graceful error handling for tracing failures

## Span Hierarchy

```
Session
└── Request
    └── Agent (traced_agent)
        ├── Tool (traced_tool)
        └── Generation (traced_generation)
```

## API

```python
from src.observability import traced_agent, traced_tool, TraceContext

@traced_agent("research_agent")
async def research(state: AgentState) -> AgentState:
    ...

@traced_tool("market_data")
async def get_market_data(symbol: str) -> dict:
    ...

async with TraceContext(session_id="user-123", user_id="user-123"):
    result = await research(state)
```

## Environment Variables

- `LANGFUSE_PUBLIC_KEY`: Public API key
- `LANGFUSE_SECRET_KEY`: Secret API key  
- `LANGFUSE_HOST`: Host URL (default: http://localhost:3000)

## Test plan

- [x] Test client creation with env vars
- [x] Test fallback to get_client when env vars not set
- [x] Test traced_agent with async and sync functions
- [x] Test traced_tool with async and sync functions
- [x] Test traced_generation with async and sync functions
- [x] Test TraceContext as async and sync context manager
- [x] Test flush_traces and shutdown_tracing
- [x] Test error handling for flush/shutdown
- [x] Run ruff linting - passes
- [x] Run mypy type checking - passes
- [x] All 17 tests pass

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)