### PR TITLE
Add tool interface pattern with mock fallback

### DIFF
--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -6,3 +6,21 @@ This module contains tools for:
 - Risk calculations
 - Trade generation
 """
+
+from src.tools.base import (
+    BaseTool,
+    ToolExecutionError,
+    ToolInput,
+    ToolOutput,
+    ToolRegistry,
+    default_registry,
+)
+
+__all__ = [
+    "BaseTool",
+    "ToolExecutionError",
+    "ToolInput",
+    "ToolOutput",
+    "ToolRegistry",
+    "default_registry",
+]

--- a/src/tools/base.py
+++ b/src/tools/base.py
@@ -1,0 +1,382 @@
+"""Base tool interface for agent tools.
+
+This module provides the abstract base class for all tools used by agents,
+with support for real API execution and mock fallbacks.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, Generic, ParamSpec, TypeVar
+
+import structlog
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+logger = structlog.get_logger(__name__)
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def _get_traced_tool_decorator() -> Callable[[str], Callable[[Callable[P, T]], Callable[P, T]]]:
+    """Get the traced_tool decorator if available, otherwise return a no-op.
+
+    This allows the tools module to work independently of the tracing module.
+    """
+    try:
+        from src.observability.tracing import (  # type: ignore[import-untyped]
+            traced_tool as _traced_tool,
+        )
+
+        return _traced_tool  # type: ignore[no-any-return]
+    except ImportError:
+        # Tracing not available, return no-op decorator
+        def noop_decorator(
+            name: str,  # noqa: ARG001
+        ) -> Callable[[Callable[P, T]], Callable[P, T]]:
+            def decorator(func: Callable[P, T]) -> Callable[P, T]:
+                @wraps(func)
+                def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+                    return func(*args, **kwargs)
+
+                return wrapper
+
+            return decorator
+
+        return noop_decorator
+
+
+traced_tool = _get_traced_tool_decorator()
+
+
+class ToolInput(BaseModel):
+    """Base class for tool input validation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ToolOutput(BaseModel):
+    """Base class for tool output validation."""
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool = True
+    error: str | None = None
+
+
+InputT = TypeVar("InputT", bound=ToolInput)
+OutputT = TypeVar("OutputT", bound=ToolOutput)
+
+
+class ToolExecutionError(Exception):
+    """Raised when tool execution fails."""
+
+    def __init__(self, tool_name: str, message: str, cause: Exception | None = None) -> None:
+        self.tool_name = tool_name
+        self.cause = cause
+        super().__init__(f"{tool_name}: {message}")
+
+
+class BaseTool(ABC, Generic[InputT, OutputT]):
+    """Abstract base class for all agent tools.
+
+    Provides a consistent interface for tool execution with:
+    - Input/output validation via Pydantic models
+    - Automatic fallback to mock data on real API failures
+    - Execution tracing via Langfuse
+    - Structured logging
+
+    Type Parameters:
+        InputT: Pydantic model for input validation
+        OutputT: Pydantic model for output validation
+
+    Example:
+        class MarketDataInput(ToolInput):
+            symbol: str
+
+        class MarketDataOutput(ToolOutput):
+            price: float
+            volume: int
+
+        class MarketDataTool(BaseTool[MarketDataInput, MarketDataOutput]):
+            name = "market_data"
+            description = "Fetches current market data for a symbol"
+
+            async def _execute_real(self, input: MarketDataInput) -> MarketDataOutput:
+                # Call real API
+                ...
+
+            async def _execute_mock(self, input: MarketDataInput) -> MarketDataOutput:
+                return MarketDataOutput(price=150.0, volume=1000000)
+    """
+
+    #: Unique name for the tool
+    name: str
+    #: Human-readable description of what the tool does
+    description: str
+    #: Whether to use mock data instead of real API
+    use_mock: bool = False
+    #: Whether to fallback to mock on real API failure
+    fallback_to_mock: bool = True
+
+    def __init__(
+        self,
+        use_mock: bool | None = None,
+        fallback_to_mock: bool | None = None,
+    ) -> None:
+        """Initialize the tool.
+
+        Args:
+            use_mock: Override default mock setting.
+            fallback_to_mock: Override default fallback setting.
+        """
+        if use_mock is not None:
+            self.use_mock = use_mock
+        if fallback_to_mock is not None:
+            self.fallback_to_mock = fallback_to_mock
+
+        self._logger = logger.bind(tool=self.name)
+
+    @property
+    @abstractmethod
+    def input_schema(self) -> type[InputT]:
+        """Return the Pydantic model for input validation."""
+        ...
+
+    @property
+    @abstractmethod
+    def output_schema(self) -> type[OutputT]:
+        """Return the Pydantic model for output validation."""
+        ...
+
+    @abstractmethod
+    async def _execute_real(self, input_data: InputT) -> OutputT:
+        """Execute the tool with real API.
+
+        Args:
+            input_data: Validated input data.
+
+        Returns:
+            Tool output.
+
+        Raises:
+            Exception: If the real API call fails.
+        """
+        ...
+
+    @abstractmethod
+    async def _execute_mock(self, input_data: InputT) -> OutputT:
+        """Execute the tool with mock data.
+
+        Args:
+            input_data: Validated input data.
+
+        Returns:
+            Mock tool output.
+        """
+        ...
+
+    def _validate_input(self, input_data: dict[str, Any] | InputT) -> InputT:
+        """Validate and parse input data.
+
+        Args:
+            input_data: Raw input dict or already validated model.
+
+        Returns:
+            Validated input model.
+
+        Raises:
+            ToolExecutionError: If validation fails.
+        """
+        if isinstance(input_data, self.input_schema):
+            return input_data
+
+        try:
+            return self.input_schema.model_validate(input_data)
+        except ValidationError as e:
+            raise ToolExecutionError(
+                self.name,
+                f"Input validation failed: {e}",
+                cause=e,
+            ) from e
+
+    def _validate_output(self, output_data: OutputT) -> OutputT:
+        """Validate output data.
+
+        Args:
+            output_data: Output to validate.
+
+        Returns:
+            Validated output model.
+
+        Raises:
+            ToolExecutionError: If validation fails.
+        """
+        try:
+            # Re-validate to ensure all fields are correct
+            return self.output_schema.model_validate(output_data.model_dump())
+        except ValidationError as e:
+            raise ToolExecutionError(
+                self.name,
+                f"Output validation failed: {e}",
+                cause=e,
+            ) from e
+
+    async def execute(self, input_data: dict[str, Any] | InputT) -> OutputT:
+        """Execute the tool with input validation and fallback handling.
+
+        This is the main entry point for tool execution. It:
+        1. Validates input against the input schema
+        2. Executes real API (or mock if use_mock=True)
+        3. Falls back to mock on failure if fallback_to_mock=True
+        4. Validates output against the output schema
+
+        Args:
+            input_data: Raw input dict or validated input model.
+
+        Returns:
+            Validated tool output.
+
+        Raises:
+            ToolExecutionError: If execution fails and fallback is disabled.
+        """
+        # Apply tracing decorator dynamically
+        return await self._traced_execute(input_data)
+
+    @traced_tool("tool_execution")
+    async def _traced_execute(self, input_data: dict[str, Any] | InputT) -> OutputT:
+        """Internal traced execution method."""
+        validated_input = self._validate_input(input_data)
+
+        self._logger.info(
+            "tool_execute_start",
+            use_mock=self.use_mock,
+            input=validated_input.model_dump(),
+        )
+
+        output: OutputT
+        if self.use_mock:
+            output = await self._execute_mock(validated_input)
+            self._logger.debug("tool_executed_mock")
+        else:
+            try:
+                output = await self._execute_real(validated_input)
+                self._logger.debug("tool_executed_real")
+            except Exception as e:
+                self._logger.warning(
+                    "tool_real_execution_failed",
+                    error=str(e),
+                    fallback_to_mock=self.fallback_to_mock,
+                )
+                if self.fallback_to_mock:
+                    output = await self._execute_mock(validated_input)
+                    output.success = True
+                    output.error = f"Fallback to mock: {e}"
+                    self._logger.info("tool_fallback_to_mock")
+                else:
+                    raise ToolExecutionError(
+                        self.name,
+                        f"Execution failed: {e}",
+                        cause=e,
+                    ) from e
+
+        validated_output = self._validate_output(output)
+        self._logger.info(
+            "tool_execute_complete",
+            success=validated_output.success,
+        )
+        return validated_output
+
+    def to_anthropic_tool(self) -> dict[str, Any]:
+        """Convert tool to Anthropic tool format for LLM function calling.
+
+        Returns:
+            Tool definition in Anthropic's expected format.
+        """
+        schema = self.input_schema.model_json_schema()
+        # Remove title and description from schema as they go in tool definition
+        schema.pop("title", None)
+        schema.pop("description", None)
+
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": schema,
+        }
+
+
+class ToolRegistry:
+    """Registry for managing available tools.
+
+    Provides a central place to register and retrieve tools by name.
+
+    Example:
+        registry = ToolRegistry()
+        registry.register(MarketDataTool())
+        tool = registry.get("market_data")
+    """
+
+    def __init__(self) -> None:
+        """Initialize empty registry."""
+        self._tools: dict[str, BaseTool[Any, Any]] = {}
+        self._logger = logger.bind(component="tool_registry")
+
+    def register(self, tool: BaseTool[Any, Any]) -> None:
+        """Register a tool in the registry.
+
+        Args:
+            tool: Tool instance to register.
+
+        Raises:
+            ValueError: If a tool with the same name is already registered.
+        """
+        if tool.name in self._tools:
+            raise ValueError(f"Tool '{tool.name}' is already registered")
+        self._tools[tool.name] = tool
+        self._logger.debug("tool_registered", tool=tool.name)
+
+    def get(self, name: str) -> BaseTool[Any, Any]:
+        """Get a tool by name.
+
+        Args:
+            name: Name of the tool to retrieve.
+
+        Returns:
+            The registered tool.
+
+        Raises:
+            KeyError: If no tool with the given name is registered.
+        """
+        if name not in self._tools:
+            raise KeyError(f"Tool '{name}' is not registered")
+        return self._tools[name]
+
+    def list_tools(self) -> list[str]:
+        """List all registered tool names.
+
+        Returns:
+            List of tool names.
+        """
+        return list(self._tools.keys())
+
+    def to_anthropic_tools(self) -> list[dict[str, Any]]:
+        """Convert all registered tools to Anthropic format.
+
+        Returns:
+            List of tool definitions in Anthropic's expected format.
+        """
+        return [tool.to_anthropic_tool() for tool in self._tools.values()]
+
+    def set_mock_mode(self, use_mock: bool) -> None:
+        """Set mock mode for all registered tools.
+
+        Args:
+            use_mock: Whether to use mock mode.
+        """
+        for tool in self._tools.values():
+            tool.use_mock = use_mock
+        self._logger.info("mock_mode_set", use_mock=use_mock, tool_count=len(self._tools))
+
+
+# Global default registry
+default_registry = ToolRegistry()

--- a/tests/test_tools/test_base.py
+++ b/tests/test_tools/test_base.py
@@ -1,0 +1,259 @@
+"""Tests for the base tool interface."""
+
+import pytest
+from pydantic import ValidationError
+
+from src.tools.base import (
+    BaseTool,
+    ToolExecutionError,
+    ToolInput,
+    ToolOutput,
+    ToolRegistry,
+)
+
+
+# Test input/output models
+class SampleInput(ToolInput):
+    """Sample input model for testing."""
+
+    value: str
+
+
+class SampleOutput(ToolOutput):
+    """Sample output model for testing."""
+
+    result: str
+
+
+# Concrete tool for testing
+class SampleTool(BaseTool[SampleInput, SampleOutput]):
+    """Concrete tool implementation for testing."""
+
+    name = "test_tool"
+    description = "A test tool"
+
+    def __init__(
+        self,
+        use_mock: bool | None = None,
+        fallback_to_mock: bool | None = None,
+        fail_real: bool = False,
+    ) -> None:
+        super().__init__(use_mock=use_mock, fallback_to_mock=fallback_to_mock)
+        self.fail_real = fail_real
+        self.real_called = False
+        self.mock_called = False
+
+    @property
+    def input_schema(self) -> type[SampleInput]:
+        return SampleInput
+
+    @property
+    def output_schema(self) -> type[SampleOutput]:
+        return SampleOutput
+
+    async def _execute_real(self, input_data: SampleInput) -> SampleOutput:
+        self.real_called = True
+        if self.fail_real:
+            raise ConnectionError("API unavailable")
+        return SampleOutput(result=f"real:{input_data.value}")
+
+    async def _execute_mock(self, input_data: SampleInput) -> SampleOutput:
+        self.mock_called = True
+        return SampleOutput(result=f"mock:{input_data.value}")
+
+
+class TestToolInput:
+    """Tests for ToolInput base class."""
+
+    def test_forbids_extra_fields(self) -> None:
+        """Test that extra fields are forbidden."""
+        with pytest.raises(ValidationError):
+            SampleInput(value="test", extra="not allowed")  # type: ignore[call-arg]
+
+    def test_valid_input(self) -> None:
+        """Test valid input creation."""
+        input_data = SampleInput(value="test")
+        assert input_data.value == "test"
+
+
+class TestToolOutput:
+    """Tests for ToolOutput base class."""
+
+    def test_default_values(self) -> None:
+        """Test default values."""
+        output = SampleOutput(result="test")
+        assert output.success is True
+        assert output.error is None
+
+    def test_allows_extra_fields(self) -> None:
+        """Test that extra fields are allowed in output."""
+        output = SampleOutput(result="test", extra_data="allowed")  # type: ignore[call-arg]
+        assert output.extra_data == "allowed"  # type: ignore[attr-defined]
+
+
+class TestBaseTool:
+    """Tests for BaseTool abstract class."""
+
+    @pytest.mark.asyncio
+    async def test_execute_real(self) -> None:
+        """Test real execution."""
+        tool = SampleTool()
+        result = await tool.execute({"value": "test"})
+
+        assert result.result == "real:test"
+        assert result.success is True
+        assert tool.real_called is True
+        assert tool.mock_called is False
+
+    @pytest.mark.asyncio
+    async def test_execute_mock(self) -> None:
+        """Test mock execution."""
+        tool = SampleTool(use_mock=True)
+        result = await tool.execute({"value": "test"})
+
+        assert result.result == "mock:test"
+        assert result.success is True
+        assert tool.real_called is False
+        assert tool.mock_called is True
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_mock(self) -> None:
+        """Test fallback to mock on real failure."""
+        tool = SampleTool(fail_real=True, fallback_to_mock=True)
+        result = await tool.execute({"value": "test"})
+
+        assert result.result == "mock:test"
+        assert result.success is True
+        assert "Fallback to mock" in (result.error or "")
+        assert tool.real_called is True
+        assert tool.mock_called is True
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_raises(self) -> None:
+        """Test that error is raised when fallback is disabled."""
+        tool = SampleTool(fail_real=True, fallback_to_mock=False)
+
+        with pytest.raises(ToolExecutionError) as exc_info:
+            await tool.execute({"value": "test"})
+
+        assert "test_tool" in str(exc_info.value)
+        assert tool.real_called is True
+        assert tool.mock_called is False
+
+    @pytest.mark.asyncio
+    async def test_input_validation(self) -> None:
+        """Test input validation."""
+        tool = SampleTool()
+
+        with pytest.raises(ToolExecutionError) as exc_info:
+            await tool.execute({"invalid_field": "test"})
+
+        assert "Input validation failed" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_accepts_model_input(self) -> None:
+        """Test that validated model can be passed directly."""
+        tool = SampleTool()
+        input_data = SampleInput(value="test")
+        result = await tool.execute(input_data)
+
+        assert result.result == "real:test"
+
+    def test_to_anthropic_tool(self) -> None:
+        """Test conversion to Anthropic tool format."""
+        tool = SampleTool()
+        anthropic_tool = tool.to_anthropic_tool()
+
+        assert anthropic_tool["name"] == "test_tool"
+        assert anthropic_tool["description"] == "A test tool"
+        assert "input_schema" in anthropic_tool
+        assert "properties" in anthropic_tool["input_schema"]
+        assert "value" in anthropic_tool["input_schema"]["properties"]
+
+
+class TestToolRegistry:
+    """Tests for ToolRegistry."""
+
+    def test_register_and_get(self) -> None:
+        """Test registering and retrieving a tool."""
+        registry = ToolRegistry()
+        tool = SampleTool()
+
+        registry.register(tool)
+        retrieved = registry.get("test_tool")
+
+        assert retrieved is tool
+
+    def test_register_duplicate_raises(self) -> None:
+        """Test that registering duplicate raises error."""
+        registry = ToolRegistry()
+        tool1 = SampleTool()
+        tool2 = SampleTool()
+
+        registry.register(tool1)
+
+        with pytest.raises(ValueError, match="already registered"):
+            registry.register(tool2)
+
+    def test_get_unknown_raises(self) -> None:
+        """Test that getting unknown tool raises error."""
+        registry = ToolRegistry()
+
+        with pytest.raises(KeyError, match="not registered"):
+            registry.get("unknown_tool")
+
+    def test_list_tools(self) -> None:
+        """Test listing registered tools."""
+        registry = ToolRegistry()
+        tool = SampleTool()
+
+        assert registry.list_tools() == []
+
+        registry.register(tool)
+        assert registry.list_tools() == ["test_tool"]
+
+    def test_to_anthropic_tools(self) -> None:
+        """Test converting all tools to Anthropic format."""
+        registry = ToolRegistry()
+        tool = SampleTool()
+        registry.register(tool)
+
+        tools = registry.to_anthropic_tools()
+
+        assert len(tools) == 1
+        assert tools[0]["name"] == "test_tool"
+
+    def test_set_mock_mode(self) -> None:
+        """Test setting mock mode for all tools."""
+        registry = ToolRegistry()
+        tool1 = SampleTool()
+        tool2 = SampleTool()
+        tool2.name = "test_tool_2"  # Change name to avoid duplicate
+
+        registry.register(tool1)
+        registry.register(tool2)
+
+        assert tool1.use_mock is False
+        assert tool2.use_mock is False
+
+        registry.set_mock_mode(True)
+
+        assert tool1.use_mock is True
+        assert tool2.use_mock is True
+
+
+class TestToolExecutionError:
+    """Tests for ToolExecutionError."""
+
+    def test_error_message(self) -> None:
+        """Test error message format."""
+        error = ToolExecutionError("my_tool", "Something went wrong")
+        assert str(error) == "my_tool: Something went wrong"
+
+    def test_with_cause(self) -> None:
+        """Test error with cause."""
+        cause = ValueError("Original error")
+        error = ToolExecutionError("my_tool", "Wrapper", cause=cause)
+
+        assert error.cause is cause
+        assert error.tool_name == "my_tool"


### PR DESCRIPTION
## Summary

- Creates `BaseTool` abstract class with generic typing for input/output models
- Implements `ToolInput`/`ToolOutput` Pydantic models for validation
- Adds automatic mock fallback mechanism on real API failures
- Provides `ToolRegistry` for managing and configuring tools
- Includes Anthropic tool format conversion for LLM function calling
- Optional Langfuse tracing integration (gracefully degrades if tracing unavailable)

## API

```python
from src.tools import BaseTool, ToolInput, ToolOutput, ToolRegistry

class MarketDataInput(ToolInput):
    symbol: str

class MarketDataOutput(ToolOutput):
    price: float
    volume: int

class MarketDataTool(BaseTool[MarketDataInput, MarketDataOutput]):
    name = "market_data"
    description = "Fetches market data for a symbol"

    @property
    def input_schema(self) -> type[MarketDataInput]:
        return MarketDataInput

    @property
    def output_schema(self) -> type[MarketDataOutput]:
        return MarketDataOutput

    async def _execute_real(self, input: MarketDataInput) -> MarketDataOutput:
        # Call real API
        ...

    async def _execute_mock(self, input: MarketDataInput) -> MarketDataOutput:
        return MarketDataOutput(price=150.0, volume=1000000)

# Usage
tool = MarketDataTool(fallback_to_mock=True)
result = await tool.execute({"symbol": "AAPL"})

# Registry
registry = ToolRegistry()
registry.register(tool)
registry.set_mock_mode(True)  # Enable mock mode for all tools
```

## Features

- **Input validation**: Pydantic models with `extra="forbid"` prevent unexpected fields
- **Output validation**: Pydantic models with `extra="allow"` for flexibility
- **Mock fallback**: Automatically falls back to mock on API failures
- **Tool registry**: Central management of tools with bulk mock mode toggle
- **Anthropic format**: `to_anthropic_tool()` for LLM function calling
- **Tracing**: Optional Langfuse tracing (works without tracing module)

## Test plan

- [x] Test ToolInput forbids extra fields
- [x] Test ToolOutput allows extra fields
- [x] Test BaseTool real execution
- [x] Test BaseTool mock execution
- [x] Test automatic fallback to mock on failure
- [x] Test error raised when fallback disabled
- [x] Test input validation errors
- [x] Test Anthropic tool format conversion
- [x] Test ToolRegistry register/get/list
- [x] Test ToolRegistry duplicate registration error
- [x] Test ToolRegistry mock mode toggle
- [x] Run ruff linting - passes
- [x] Run mypy type checking - passes
- [x] All 32 tests pass (including existing tests)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)