### PR TITLE
Add Research Agent with market data and news gathering

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -7,5 +7,18 @@ This module contains specialized agents:
 """
 
 from src.agents.base import AgentState, BaseAgent
+from src.agents.research import (
+    NewsItem,
+    ResearchAgent,
+    ResearchOutput,
+    SymbolData,
+)
 
-__all__ = ["AgentState", "BaseAgent"]
+__all__ = [
+    "AgentState",
+    "BaseAgent",
+    "NewsItem",
+    "ResearchAgent",
+    "ResearchOutput",
+    "SymbolData",
+]

--- a/src/agents/research.py
+++ b/src/agents/research.py
@@ -1,0 +1,411 @@
+"""Research Agent for gathering market data and information.
+
+This module implements the ResearchAgent that collects market data,
+news, and other financial information for portfolio analysis.
+"""
+
+from typing import Any
+
+import structlog
+from pydantic import BaseModel, Field
+
+from src.agents.base import AgentState, BaseAgent
+from src.observability.tracing import traced_agent
+from src.tools.base import BaseTool, ToolInput, ToolOutput, ToolRegistry
+
+logger = structlog.get_logger(__name__)
+
+
+# ============================================================================
+# Output Schema
+# ============================================================================
+
+
+class NewsItem(BaseModel):
+    """A single news item."""
+
+    title: str
+    source: str
+    url: str | None = None
+    summary: str | None = None
+    sentiment: str | None = None  # positive, negative, neutral
+    published_at: str | None = None
+
+
+class SymbolData(BaseModel):
+    """Market data for a single symbol."""
+
+    symbol: str
+    price: float | None = None
+    change_percent: float | None = None
+    volume: int | None = None
+    market_cap: float | None = None
+    pe_ratio: float | None = None
+    dividend_yield: float | None = None
+
+
+class ResearchOutput(BaseModel):
+    """Structured output from the Research Agent.
+
+    Contains all gathered market data, news, and analysis summary.
+    """
+
+    symbols_analyzed: list[str] = Field(default_factory=list)
+    market_data: dict[str, SymbolData] = Field(default_factory=dict)
+    news_items: list[NewsItem] = Field(default_factory=list)
+    summary: str = ""
+    sources: list[str] = Field(default_factory=list)
+    errors: list[str] = Field(default_factory=list)
+
+
+# ============================================================================
+# Placeholder Tool Inputs/Outputs (to be replaced by actual tool implementations)
+# ============================================================================
+
+
+class MarketDataInput(ToolInput):
+    """Input for market data tool."""
+
+    symbol: str
+
+
+class MarketDataOutput(ToolOutput):
+    """Output from market data tool."""
+
+    symbol: str
+    price: float
+    change_percent: float
+    volume: int
+    market_cap: float | None = None
+    pe_ratio: float | None = None
+    dividend_yield: float | None = None
+
+
+class NewsSearchInput(ToolInput):
+    """Input for news search tool."""
+
+    query: str
+    max_results: int = 5
+
+
+class NewsSearchOutput(ToolOutput):
+    """Output from news search tool."""
+
+    items: list[NewsItem] = Field(default_factory=list)
+
+
+# ============================================================================
+# Placeholder Tools (to be replaced by actual implementations in #10 and #11)
+# ============================================================================
+
+
+class PlaceholderMarketDataTool(BaseTool[MarketDataInput, MarketDataOutput]):
+    """Placeholder market data tool for testing.
+
+    Will be replaced by actual implementation in issue #10.
+    """
+
+    name = "get_market_data"
+    description = "Fetches current market data for a stock symbol including price, volume, and key metrics"
+
+    @property
+    def input_schema(self) -> type[MarketDataInput]:
+        return MarketDataInput
+
+    @property
+    def output_schema(self) -> type[MarketDataOutput]:
+        return MarketDataOutput
+
+    async def _execute_real(self, input_data: MarketDataInput) -> MarketDataOutput:
+        """Real implementation - placeholder raises to trigger mock fallback."""
+        raise NotImplementedError("Real market data API not yet implemented")
+
+    async def _execute_mock(self, input_data: MarketDataInput) -> MarketDataOutput:
+        """Mock implementation with sample data."""
+        # Mock data based on symbol
+        mock_data = {
+            "AAPL": {"price": 178.50, "change": 1.25, "volume": 52_000_000, "cap": 2.8e12, "pe": 28.5},
+            "GOOGL": {"price": 141.80, "change": -0.45, "volume": 21_000_000, "cap": 1.8e12, "pe": 25.2},
+            "MSFT": {"price": 378.90, "change": 0.82, "volume": 18_000_000, "cap": 2.9e12, "pe": 35.1},
+        }
+
+        data = mock_data.get(
+            input_data.symbol.upper(),
+            {"price": 100.0, "change": 0.0, "volume": 1_000_000, "cap": 1e9, "pe": 20.0},
+        )
+
+        return MarketDataOutput(
+            symbol=input_data.symbol.upper(),
+            price=data["price"],
+            change_percent=data["change"],
+            volume=int(data["volume"]),
+            market_cap=data["cap"],
+            pe_ratio=data["pe"],
+        )
+
+
+class PlaceholderNewsSearchTool(BaseTool[NewsSearchInput, NewsSearchOutput]):
+    """Placeholder news search tool for testing.
+
+    Will be replaced by actual implementation in issue #11.
+    """
+
+    name = "search_news"
+    description = "Searches for recent financial news related to a query or stock symbol"
+
+    @property
+    def input_schema(self) -> type[NewsSearchInput]:
+        return NewsSearchInput
+
+    @property
+    def output_schema(self) -> type[NewsSearchOutput]:
+        return NewsSearchOutput
+
+    async def _execute_real(self, input_data: NewsSearchInput) -> NewsSearchOutput:
+        """Real implementation - placeholder raises to trigger mock fallback."""
+        raise NotImplementedError("Real news search API not yet implemented")
+
+    async def _execute_mock(self, input_data: NewsSearchInput) -> NewsSearchOutput:
+        """Mock implementation with sample news."""
+        items = [
+            NewsItem(
+                title=f"Market Update: {input_data.query} shows strong momentum",
+                source="Financial Times",
+                url="https://ft.com/example",
+                summary=f"Analysis of recent {input_data.query} performance and outlook.",
+                sentiment="positive",
+                published_at="2024-01-15T10:30:00Z",
+            ),
+            NewsItem(
+                title=f"Analyst Report: {input_data.query} earnings preview",
+                source="Bloomberg",
+                url="https://bloomberg.com/example",
+                summary="Upcoming earnings expectations and key metrics to watch.",
+                sentiment="neutral",
+                published_at="2024-01-15T09:15:00Z",
+            ),
+        ]
+        return NewsSearchOutput(items=items[: input_data.max_results])
+
+
+# ============================================================================
+# Research Agent
+# ============================================================================
+
+
+class ResearchAgent(BaseAgent):
+    """Agent that gathers market data and financial information.
+
+    The Research Agent is the first step in the portfolio analysis workflow.
+    It collects market data, news, and other relevant information for the
+    symbols in the portfolio.
+
+    Tools:
+        - get_market_data: Fetches current market data for symbols
+        - search_news: Searches for relevant financial news
+
+    Output:
+        ResearchOutput containing market data, news items, and summary
+    """
+
+    def __init__(
+        self,
+        tool_registry: ToolRegistry | None = None,
+        use_mock_tools: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the Research Agent.
+
+        Args:
+            tool_registry: Optional custom tool registry. If not provided,
+                creates a new one with placeholder tools.
+            use_mock_tools: Whether to use mock mode for tools.
+            **kwargs: Additional arguments passed to BaseAgent.
+        """
+        super().__init__(**kwargs)
+
+        # Set up tool registry
+        if tool_registry is not None:
+            self._tool_registry = tool_registry
+        else:
+            self._tool_registry = ToolRegistry()
+            self._tool_registry.register(
+                PlaceholderMarketDataTool(use_mock=use_mock_tools)
+            )
+            self._tool_registry.register(
+                PlaceholderNewsSearchTool(use_mock=use_mock_tools)
+            )
+
+    @property
+    def name(self) -> str:
+        return "research"
+
+    @property
+    def description(self) -> str:
+        return "Gathers market data and financial information for portfolio analysis"
+
+    @property
+    def system_prompt(self) -> str:
+        return """You are a financial research agent specialized in gathering market data and information.
+
+Your role is to:
+1. Collect current market data for requested stock symbols
+2. Search for relevant financial news
+3. Compile a structured research document
+
+Available tools:
+- get_market_data: Fetches current price, volume, and key metrics for a stock symbol
+- search_news: Searches for recent financial news related to a query
+
+Guidelines:
+- Always gather market data for all requested symbols
+- Search for news related to the portfolio or specific symbols
+- Report any errors or missing data clearly
+- Provide a brief summary of your findings
+
+Output your findings in a structured format with:
+- Market data for each symbol
+- Relevant news items
+- A summary of key observations
+- List of data sources used"""
+
+    @property
+    def tools(self) -> list[dict[str, Any]]:
+        """Return tools in Anthropic format."""
+        return self._tool_registry.to_anthropic_tools()
+
+    def get_tool(self, name: str) -> BaseTool[Any, Any]:
+        """Get a tool by name from the registry.
+
+        Args:
+            name: Name of the tool.
+
+        Returns:
+            The tool instance.
+        """
+        return self._tool_registry.get(name)
+
+    @traced_agent("research_agent")
+    async def invoke(self, state: AgentState) -> AgentState:
+        """Execute the research agent workflow.
+
+        Args:
+            state: Current workflow state containing:
+                - context.symbols: List of symbols to analyze
+                - context.portfolio: Optional portfolio details
+
+        Returns:
+            Updated state with research results in context.research
+        """
+        self._logger.info("research_invoke_start", context_keys=list(state.context.keys()))
+
+        # Extract symbols from state
+        symbols: list[str] = state.context.get("symbols", [])
+        if not symbols:
+            self._logger.warning("no_symbols_provided")
+            state.errors.append("ResearchAgent: No symbols provided in context")
+            return state
+
+        # Initialize output
+        output = ResearchOutput(symbols_analyzed=symbols)
+
+        # Gather market data for each symbol
+        market_data_tool = self.get_tool("get_market_data")
+        for symbol in symbols:
+            try:
+                result = await market_data_tool.execute({"symbol": symbol})
+                output.market_data[symbol] = SymbolData(
+                    symbol=result.symbol,
+                    price=result.price,
+                    change_percent=result.change_percent,
+                    volume=result.volume,
+                    market_cap=result.market_cap,
+                    pe_ratio=result.pe_ratio,
+                    dividend_yield=result.dividend_yield,
+                )
+                output.sources.append(f"Market data for {symbol}")
+                self._logger.debug("market_data_collected", symbol=symbol)
+            except Exception as e:
+                error_msg = f"Failed to get market data for {symbol}: {e}"
+                output.errors.append(error_msg)
+                self._logger.warning("market_data_failed", symbol=symbol, error=str(e))
+
+        # Search for relevant news
+        news_tool = self.get_tool("search_news")
+        try:
+            # Search for portfolio-related news
+            query = " ".join(symbols[:3])  # Use first 3 symbols as query
+            news_result = await news_tool.execute({"query": query, "max_results": 5})
+            output.news_items = news_result.items
+            output.sources.append(f"News search for: {query}")
+            self._logger.debug("news_collected", item_count=len(news_result.items))
+        except Exception as e:
+            error_msg = f"Failed to search news: {e}"
+            output.errors.append(error_msg)
+            self._logger.warning("news_search_failed", error=str(e))
+
+        # Generate summary
+        output.summary = self._generate_summary(output)
+
+        # Update state with research results
+        state.context["research"] = output.model_dump()
+        state.messages.append({
+            "role": "assistant",
+            "content": f"Research completed for {len(symbols)} symbols. "
+                       f"Collected {len(output.market_data)} market data entries "
+                       f"and {len(output.news_items)} news items.",
+        })
+
+        self._logger.info(
+            "research_invoke_complete",
+            symbols_count=len(symbols),
+            market_data_count=len(output.market_data),
+            news_count=len(output.news_items),
+            error_count=len(output.errors),
+        )
+
+        return state
+
+    def _generate_summary(self, output: ResearchOutput) -> str:
+        """Generate a summary of research findings.
+
+        Args:
+            output: The research output to summarize.
+
+        Returns:
+            Summary string.
+        """
+        parts = []
+
+        # Market data summary
+        if output.market_data:
+            gainers = []
+            losers = []
+            for symbol, data in output.market_data.items():
+                if data.change_percent is not None:
+                    if data.change_percent > 0:
+                        gainers.append((symbol, data.change_percent))
+                    elif data.change_percent < 0:
+                        losers.append((symbol, data.change_percent))
+
+            if gainers:
+                top_gainer = max(gainers, key=lambda x: x[1])
+                parts.append(f"Top gainer: {top_gainer[0]} (+{top_gainer[1]:.2f}%)")
+            if losers:
+                top_loser = min(losers, key=lambda x: x[1])
+                parts.append(f"Top loser: {top_loser[0]} ({top_loser[1]:.2f}%)")
+
+        # News summary
+        if output.news_items:
+            positive_count = sum(1 for n in output.news_items if n.sentiment == "positive")
+            negative_count = sum(1 for n in output.news_items if n.sentiment == "negative")
+            parts.append(
+                f"News sentiment: {positive_count} positive, {negative_count} negative, "
+                f"{len(output.news_items) - positive_count - negative_count} neutral"
+            )
+
+        # Error summary
+        if output.errors:
+            parts.append(f"Encountered {len(output.errors)} error(s) during research")
+
+        return ". ".join(parts) if parts else "Research completed successfully."

--- a/tests/test_agents/test_research.py
+++ b/tests/test_agents/test_research.py
@@ -1,0 +1,419 @@
+"""Tests for the Research Agent."""
+
+import pytest
+
+from src.agents.base import AgentState
+from src.agents.research import (
+    MarketDataInput,
+    MarketDataOutput,
+    NewsItem,
+    NewsSearchInput,
+    NewsSearchOutput,
+    PlaceholderMarketDataTool,
+    PlaceholderNewsSearchTool,
+    ResearchAgent,
+    ResearchOutput,
+    SymbolData,
+)
+from src.tools.base import ToolRegistry
+
+
+class TestNewsItem:
+    """Tests for NewsItem model."""
+
+    def test_required_fields(self) -> None:
+        """Test that required fields work."""
+        item = NewsItem(title="Test News", source="Test Source")
+        assert item.title == "Test News"
+        assert item.source == "Test Source"
+        assert item.url is None
+        assert item.summary is None
+        assert item.sentiment is None
+        assert item.published_at is None
+
+    def test_all_fields(self) -> None:
+        """Test with all fields."""
+        item = NewsItem(
+            title="Market Update",
+            source="Bloomberg",
+            url="https://example.com",
+            summary="Market is up",
+            sentiment="positive",
+            published_at="2024-01-15T10:00:00Z",
+        )
+        assert item.url == "https://example.com"
+        assert item.sentiment == "positive"
+
+
+class TestSymbolData:
+    """Tests for SymbolData model."""
+
+    def test_required_fields(self) -> None:
+        """Test that only symbol is required."""
+        data = SymbolData(symbol="AAPL")
+        assert data.symbol == "AAPL"
+        assert data.price is None
+        assert data.change_percent is None
+        assert data.volume is None
+
+    def test_all_fields(self) -> None:
+        """Test with all fields."""
+        data = SymbolData(
+            symbol="AAPL",
+            price=178.50,
+            change_percent=1.25,
+            volume=52_000_000,
+            market_cap=2.8e12,
+            pe_ratio=28.5,
+            dividend_yield=0.5,
+        )
+        assert data.price == 178.50
+        assert data.market_cap == 2.8e12
+
+
+class TestResearchOutput:
+    """Tests for ResearchOutput model."""
+
+    def test_default_values(self) -> None:
+        """Test default values."""
+        output = ResearchOutput()
+        assert output.symbols_analyzed == []
+        assert output.market_data == {}
+        assert output.news_items == []
+        assert output.summary == ""
+        assert output.sources == []
+        assert output.errors == []
+
+    def test_with_data(self) -> None:
+        """Test with populated data."""
+        output = ResearchOutput(
+            symbols_analyzed=["AAPL", "GOOGL"],
+            market_data={
+                "AAPL": SymbolData(symbol="AAPL", price=178.50),
+            },
+            news_items=[
+                NewsItem(title="Test", source="Source"),
+            ],
+            summary="Test summary",
+            sources=["Source 1"],
+            errors=[],
+        )
+        assert len(output.symbols_analyzed) == 2
+        assert "AAPL" in output.market_data
+        assert len(output.news_items) == 1
+
+
+class TestPlaceholderMarketDataTool:
+    """Tests for PlaceholderMarketDataTool."""
+
+    @pytest.mark.asyncio
+    async def test_mock_known_symbol(self) -> None:
+        """Test mock data for known symbols."""
+        tool = PlaceholderMarketDataTool(use_mock=True)
+        result = await tool.execute({"symbol": "AAPL"})
+
+        assert result.symbol == "AAPL"
+        assert result.price == 178.50
+        assert result.change_percent == 1.25
+        assert result.volume == 52_000_000
+
+    @pytest.mark.asyncio
+    async def test_mock_unknown_symbol(self) -> None:
+        """Test mock data for unknown symbols returns defaults."""
+        tool = PlaceholderMarketDataTool(use_mock=True)
+        result = await tool.execute({"symbol": "UNKNOWN"})
+
+        assert result.symbol == "UNKNOWN"
+        assert result.price == 100.0
+        assert result.change_percent == 0.0
+
+    @pytest.mark.asyncio
+    async def test_real_raises_not_implemented(self) -> None:
+        """Test real implementation raises NotImplementedError."""
+        tool = PlaceholderMarketDataTool(use_mock=False, fallback_to_mock=False)
+
+        from src.tools.base import ToolExecutionError
+
+        with pytest.raises(ToolExecutionError):
+            await tool.execute({"symbol": "AAPL"})
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_mock(self) -> None:
+        """Test fallback to mock when real fails."""
+        tool = PlaceholderMarketDataTool(use_mock=False, fallback_to_mock=True)
+        result = await tool.execute({"symbol": "AAPL"})
+
+        assert result.symbol == "AAPL"
+        assert result.success is True
+        assert "Fallback to mock" in (result.error or "")
+
+    def test_to_anthropic_tool(self) -> None:
+        """Test conversion to Anthropic tool format."""
+        tool = PlaceholderMarketDataTool()
+        anthropic_tool = tool.to_anthropic_tool()
+
+        assert anthropic_tool["name"] == "get_market_data"
+        assert "market data" in anthropic_tool["description"].lower()
+        assert "symbol" in anthropic_tool["input_schema"]["properties"]
+
+
+class TestPlaceholderNewsSearchTool:
+    """Tests for PlaceholderNewsSearchTool."""
+
+    @pytest.mark.asyncio
+    async def test_mock_returns_news(self) -> None:
+        """Test mock returns news items."""
+        tool = PlaceholderNewsSearchTool(use_mock=True)
+        result = await tool.execute({"query": "AAPL", "max_results": 5})
+
+        assert len(result.items) <= 5
+        assert all(isinstance(item, NewsItem) for item in result.items)
+        assert result.items[0].source == "Financial Times"
+
+    @pytest.mark.asyncio
+    async def test_mock_respects_max_results(self) -> None:
+        """Test mock respects max_results parameter."""
+        tool = PlaceholderNewsSearchTool(use_mock=True)
+        result = await tool.execute({"query": "AAPL", "max_results": 1})
+
+        assert len(result.items) == 1
+
+    @pytest.mark.asyncio
+    async def test_real_raises_not_implemented(self) -> None:
+        """Test real implementation raises NotImplementedError."""
+        tool = PlaceholderNewsSearchTool(use_mock=False, fallback_to_mock=False)
+
+        from src.tools.base import ToolExecutionError
+
+        with pytest.raises(ToolExecutionError):
+            await tool.execute({"query": "AAPL"})
+
+    def test_to_anthropic_tool(self) -> None:
+        """Test conversion to Anthropic tool format."""
+        tool = PlaceholderNewsSearchTool()
+        anthropic_tool = tool.to_anthropic_tool()
+
+        assert anthropic_tool["name"] == "search_news"
+        assert "news" in anthropic_tool["description"].lower()
+
+
+class TestResearchAgent:
+    """Tests for ResearchAgent."""
+
+    def test_initialization_default(self) -> None:
+        """Test default initialization."""
+        agent = ResearchAgent()
+
+        assert agent.name == "research"
+        assert "market data" in agent.description.lower()
+        # Default uses mock tools - verify tools are registered
+        assert agent.get_tool("get_market_data") is not None
+        assert agent.get_tool("search_news") is not None
+
+    def test_initialization_custom_registry(self) -> None:
+        """Test initialization with custom tool registry."""
+        registry = ToolRegistry()
+        registry.register(PlaceholderMarketDataTool(use_mock=True))
+        registry.register(PlaceholderNewsSearchTool(use_mock=True))
+
+        agent = ResearchAgent(tool_registry=registry)
+
+        assert agent.get_tool("get_market_data") is not None
+        assert agent.get_tool("search_news") is not None
+
+    def test_system_prompt(self) -> None:
+        """Test system prompt contains expected content."""
+        agent = ResearchAgent()
+
+        assert "research" in agent.system_prompt.lower()
+        assert "market data" in agent.system_prompt.lower()
+        assert "news" in agent.system_prompt.lower()
+
+    def test_tools_property(self) -> None:
+        """Test tools are in Anthropic format."""
+        agent = ResearchAgent()
+        tools = agent.tools
+
+        assert len(tools) == 2
+        tool_names = [t["name"] for t in tools]
+        assert "get_market_data" in tool_names
+        assert "search_news" in tool_names
+
+    def test_get_tool(self) -> None:
+        """Test getting a tool by name."""
+        agent = ResearchAgent()
+
+        market_tool = agent.get_tool("get_market_data")
+        assert market_tool.name == "get_market_data"
+
+        news_tool = agent.get_tool("search_news")
+        assert news_tool.name == "search_news"
+
+    @pytest.mark.asyncio
+    async def test_invoke_with_symbols(self) -> None:
+        """Test invoke collects data for symbols."""
+        agent = ResearchAgent(use_mock_tools=True)
+        state = AgentState(context={"symbols": ["AAPL", "GOOGL"]})
+
+        result = await agent.invoke(state)
+
+        assert "research" in result.context
+        research = result.context["research"]
+
+        assert research["symbols_analyzed"] == ["AAPL", "GOOGL"]
+        assert "AAPL" in research["market_data"]
+        assert "GOOGL" in research["market_data"]
+        assert len(research["news_items"]) > 0
+        assert len(research["sources"]) > 0
+        assert research["summary"] != ""
+
+    @pytest.mark.asyncio
+    async def test_invoke_no_symbols(self) -> None:
+        """Test invoke handles missing symbols gracefully."""
+        agent = ResearchAgent(use_mock_tools=True)
+        state = AgentState(context={})
+
+        result = await agent.invoke(state)
+
+        assert len(result.errors) == 1
+        assert "No symbols provided" in result.errors[0]
+        assert "research" not in result.context
+
+    @pytest.mark.asyncio
+    async def test_invoke_empty_symbols(self) -> None:
+        """Test invoke handles empty symbols list."""
+        agent = ResearchAgent(use_mock_tools=True)
+        state = AgentState(context={"symbols": []})
+
+        result = await agent.invoke(state)
+
+        assert len(result.errors) == 1
+        assert "No symbols provided" in result.errors[0]
+
+    @pytest.mark.asyncio
+    async def test_invoke_adds_message(self) -> None:
+        """Test invoke adds completion message."""
+        agent = ResearchAgent(use_mock_tools=True)
+        state = AgentState(context={"symbols": ["AAPL"]})
+
+        result = await agent.invoke(state)
+
+        assert len(result.messages) == 1
+        assert result.messages[0]["role"] == "assistant"
+        assert "Research completed" in result.messages[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_invoke_generates_summary(self) -> None:
+        """Test invoke generates meaningful summary."""
+        agent = ResearchAgent(use_mock_tools=True)
+        state = AgentState(context={"symbols": ["AAPL", "GOOGL", "MSFT"]})
+
+        result = await agent.invoke(state)
+
+        research = result.context["research"]
+        summary = research["summary"]
+
+        # Should mention top gainer (AAPL has positive change)
+        assert "gainer" in summary.lower() or "loser" in summary.lower()
+        # Should mention news sentiment
+        assert "sentiment" in summary.lower() or "news" in summary.lower()
+
+    @pytest.mark.asyncio
+    async def test_invoke_callable(self) -> None:
+        """Test agent can be called as a function via BaseAgent.__call__."""
+        agent = ResearchAgent(use_mock_tools=True)
+        state = AgentState(context={"symbols": ["AAPL"]})
+
+        result = await agent(state)
+
+        assert "research" in result.context
+
+
+class TestResearchAgentSummaryGeneration:
+    """Tests for the _generate_summary method."""
+
+    def test_summary_with_gainers_and_losers(self) -> None:
+        """Test summary includes top gainer and loser."""
+        agent = ResearchAgent(use_mock_tools=True)
+        output = ResearchOutput(
+            market_data={
+                "AAPL": SymbolData(symbol="AAPL", change_percent=2.5),
+                "GOOGL": SymbolData(symbol="GOOGL", change_percent=-1.5),
+                "MSFT": SymbolData(symbol="MSFT", change_percent=0.5),
+            },
+        )
+
+        summary = agent._generate_summary(output)
+
+        assert "AAPL" in summary
+        assert "+2.50%" in summary
+        assert "GOOGL" in summary
+        assert "-1.50%" in summary
+
+    def test_summary_with_news_sentiment(self) -> None:
+        """Test summary includes news sentiment counts."""
+        agent = ResearchAgent(use_mock_tools=True)
+        output = ResearchOutput(
+            news_items=[
+                NewsItem(title="Good news", source="S1", sentiment="positive"),
+                NewsItem(title="Bad news", source="S2", sentiment="negative"),
+                NewsItem(title="Neutral news", source="S3", sentiment="neutral"),
+            ],
+        )
+
+        summary = agent._generate_summary(output)
+
+        assert "1 positive" in summary
+        assert "1 negative" in summary
+
+    def test_summary_with_errors(self) -> None:
+        """Test summary mentions errors."""
+        agent = ResearchAgent(use_mock_tools=True)
+        output = ResearchOutput(
+            errors=["Error 1", "Error 2"],
+        )
+
+        summary = agent._generate_summary(output)
+
+        assert "2 error" in summary.lower()
+
+    def test_summary_empty_output(self) -> None:
+        """Test summary for empty output."""
+        agent = ResearchAgent(use_mock_tools=True)
+        output = ResearchOutput()
+
+        summary = agent._generate_summary(output)
+
+        assert summary == "Research completed successfully."
+
+
+class TestToolInputOutputModels:
+    """Tests for tool input/output models."""
+
+    def test_market_data_input(self) -> None:
+        """Test MarketDataInput model."""
+        input_data = MarketDataInput(symbol="AAPL")
+        assert input_data.symbol == "AAPL"
+
+    def test_market_data_output(self) -> None:
+        """Test MarketDataOutput model."""
+        output = MarketDataOutput(
+            symbol="AAPL",
+            price=178.50,
+            change_percent=1.25,
+            volume=52_000_000,
+        )
+        assert output.symbol == "AAPL"
+        assert output.success is True
+
+    def test_news_search_input(self) -> None:
+        """Test NewsSearchInput model."""
+        input_data = NewsSearchInput(query="AAPL")
+        assert input_data.query == "AAPL"
+        assert input_data.max_results == 5  # default
+
+    def test_news_search_output(self) -> None:
+        """Test NewsSearchOutput model."""
+        output = NewsSearchOutput(items=[])
+        assert output.items == []
+        assert output.success is True


### PR DESCRIPTION
## Summary
- Implements `ResearchAgent` for gathering market data and financial news
- Creates output schemas: `NewsItem`, `SymbolData`, `ResearchOutput`
- Adds placeholder tools (`PlaceholderMarketDataTool`, `PlaceholderNewsSearchTool`) with mock data
- Integrates with tool registry for LLM function calling
- Adds agent-level tracing via `@traced_agent` decorator

## Implementation Details
The Research Agent is the first step in the portfolio analysis workflow:
1. Collects market data for requested symbols via `get_market_data` tool
2. Searches for relevant financial news via `search_news` tool
3. Generates a summary with top gainers/losers and sentiment analysis
4. Returns structured `ResearchOutput` in `state.context["research"]`

Placeholder tools return mock data and will be replaced by real API implementations in issues #10 and #11.

## Test plan
- [x] Unit tests for all output schemas (NewsItem, SymbolData, ResearchOutput)
- [x] Unit tests for placeholder tools (mock execution, fallback behavior)
- [x] Unit tests for ResearchAgent (initialization, invoke, summary generation)
- [x] All 82 tests passing
- [x] ruff linting passes
- [x] mypy type checking passes

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)