### PR TITLE
Add news search tool with Google News RSS and mock fallback

### DIFF
--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -21,6 +21,12 @@ from src.tools.market_data import (
     MarketDataOutput,
     MarketDataTool,
 )
+from src.tools.news_search import (
+    NewsItem,
+    NewsSearchInput,
+    NewsSearchOutput,
+    NewsSearchTool,
+)
 
 __all__ = [
     "BaseTool",
@@ -28,6 +34,10 @@ __all__ = [
     "MarketDataInput",
     "MarketDataOutput",
     "MarketDataTool",
+    "NewsItem",
+    "NewsSearchInput",
+    "NewsSearchOutput",
+    "NewsSearchTool",
     "ToolExecutionError",
     "ToolInput",
     "ToolOutput",

--- a/src/tools/news_search.py
+++ b/src/tools/news_search.py
@@ -1,0 +1,610 @@
+"""News Search Tool for fetching financial news.
+
+This module implements the NewsSearchTool that fetches news from
+Google News RSS with mock fallback support.
+"""
+
+import hashlib
+import random
+import re
+import xml.etree.ElementTree as ET
+from datetime import UTC, datetime, timedelta
+from typing import Literal
+from urllib.parse import quote
+
+import httpx
+import structlog
+from pydantic import Field
+
+from src.tools.base import BaseTool, ToolInput, ToolOutput
+
+logger = structlog.get_logger(__name__)
+
+
+# ============================================================================
+# Input/Output Schemas
+# ============================================================================
+
+
+class NewsSearchInput(ToolInput):
+    """Input for news search tool."""
+
+    query: str = Field(..., description="Search query for news articles")
+    symbols: list[str] = Field(
+        default_factory=list,
+        description="Stock symbols to include in search",
+    )
+    days_back: int = Field(
+        default=7,
+        ge=1,
+        le=30,
+        description="Number of days to search back",
+    )
+    max_results: int = Field(
+        default=10,
+        ge=1,
+        le=50,
+        description="Maximum number of results to return",
+    )
+
+
+class NewsItem(ToolOutput):
+    """A single news item."""
+
+    title: str
+    summary: str
+    source: str
+    url: str
+    published_at: str
+    relevance_score: float = Field(ge=0.0, le=1.0)
+    sentiment: Literal["positive", "negative", "neutral"] | None = None
+
+
+class NewsSearchOutput(ToolOutput):
+    """Output from news search tool."""
+
+    query: str
+    items: list[NewsItem] = Field(default_factory=list)
+    total_found: int = 0
+    source: Literal["real", "mock"]
+
+
+# ============================================================================
+# Mock Data Generator
+# ============================================================================
+
+
+# Templates for generating realistic financial news headlines
+HEADLINE_TEMPLATES = [
+    "{symbol} stock {movement} after {event}",
+    "{symbol} reports {result} earnings, {reaction}",
+    "Analysts {action} {symbol} price target to ${price}",
+    "{symbol} announces {announcement}",
+    "Breaking: {symbol} {breaking_news}",
+    "{symbol} shares {direction} on {catalyst}",
+    "Wall Street {sentiment} on {symbol} ahead of {upcoming}",
+    "{symbol} CEO discusses {topic} in interview",
+    "{symbol} beats estimates, stock {post_earnings}",
+    "Insider {insider_action} at {symbol} raises questions",
+]
+
+MOVEMENTS = ["surges", "drops", "rallies", "tumbles", "rises", "falls", "jumps", "slides"]
+EVENTS = [
+    "earnings beat",
+    "product launch",
+    "acquisition news",
+    "analyst upgrade",
+    "market rally",
+    "sector rotation",
+    "FDA approval",
+    "partnership announcement",
+]
+RESULTS = ["strong", "weak", "mixed", "record", "disappointing", "surprising"]
+REACTIONS = ["stock jumps", "shares fall", "investors cheer", "market reacts"]
+ACTIONS = ["raise", "lower", "maintain", "initiate coverage on"]
+ANNOUNCEMENTS = [
+    "new product line",
+    "strategic partnership",
+    "share buyback",
+    "dividend increase",
+    "restructuring plan",
+    "expansion into new markets",
+]
+DIRECTIONS = ["surge", "plunge", "climb", "sink", "edge higher", "edge lower"]
+CATALYSTS = [
+    "strong guidance",
+    "analyst upgrade",
+    "sector momentum",
+    "economic data",
+    "Fed comments",
+    "trade news",
+]
+SENTIMENTS = ["bullish", "bearish", "cautious", "optimistic", "uncertain"]
+UPCOMINGS = ["earnings", "product launch", "investor day", "Fed meeting", "economic report"]
+TOPICS = ["growth strategy", "market conditions", "competition", "innovation", "sustainability"]
+INSIDER_ACTIONS = ["buying", "selling", "trading activity"]
+
+SOURCES = [
+    "Reuters",
+    "Bloomberg",
+    "CNBC",
+    "Wall Street Journal",
+    "Financial Times",
+    "MarketWatch",
+    "Yahoo Finance",
+    "Barron's",
+    "Seeking Alpha",
+    "The Motley Fool",
+]
+
+
+def generate_mock_headline(symbol: str) -> tuple[str, str]:
+    """Generate a realistic mock headline for a stock symbol.
+
+    Args:
+        symbol: Stock ticker symbol.
+
+    Returns:
+        Tuple of (headline, summary).
+    """
+    template = random.choice(HEADLINE_TEMPLATES)
+    price = random.randint(50, 500)
+
+    headline = template.format(
+        symbol=symbol,
+        movement=random.choice(MOVEMENTS),
+        event=random.choice(EVENTS),
+        result=random.choice(RESULTS),
+        reaction=random.choice(REACTIONS),
+        action=random.choice(ACTIONS),
+        price=price,
+        announcement=random.choice(ANNOUNCEMENTS),
+        breaking_news=random.choice(EVENTS),
+        direction=random.choice(DIRECTIONS),
+        catalyst=random.choice(CATALYSTS),
+        sentiment=random.choice(SENTIMENTS),
+        upcoming=random.choice(UPCOMINGS),
+        topic=random.choice(TOPICS),
+        insider_action=random.choice(INSIDER_ACTIONS),
+        post_earnings=random.choice(MOVEMENTS),
+    )
+
+    # Generate a summary
+    summary = f"Financial news regarding {symbol}. {headline}. " f"Market analysts are monitoring developments closely."
+
+    return headline, summary
+
+
+def generate_mock_news(
+    query: str,
+    symbols: list[str],
+    days_back: int,
+    max_results: int,
+) -> list[NewsItem]:
+    """Generate mock news items.
+
+    Args:
+        query: Search query.
+        symbols: Stock symbols.
+        days_back: Number of days back to generate news for.
+        max_results: Maximum number of items to generate.
+
+    Returns:
+        List of mock news items.
+    """
+    items: list[NewsItem] = []
+
+    # Use symbols if provided, otherwise extract from query
+    target_symbols = symbols if symbols else [query.upper()[:5]]
+
+    now = datetime.now(UTC)
+
+    for i in range(max_results):
+        symbol = target_symbols[i % len(target_symbols)]
+        headline, summary = generate_mock_headline(symbol)
+
+        # Generate a random timestamp within the date range
+        hours_back = random.randint(1, days_back * 24)
+        published = now - timedelta(hours=hours_back)
+
+        # Generate deterministic but varied relevance score based on content
+        content_hash = hashlib.md5(headline.encode()).hexdigest()
+        base_score = int(content_hash[:2], 16) / 255  # 0-1 range
+        relevance = round(0.5 + (base_score * 0.5), 2)  # 0.5-1.0 range
+
+        # Determine sentiment from headline
+        positive_words = ["surge", "rally", "jump", "rise", "beat", "bullish", "optimistic"]
+        negative_words = ["drop", "tumble", "fall", "slide", "sink", "bearish", "disappointing"]
+
+        headline_lower = headline.lower()
+        if any(word in headline_lower for word in positive_words):
+            sentiment: Literal["positive", "negative", "neutral"] = "positive"
+        elif any(word in headline_lower for word in negative_words):
+            sentiment = "negative"
+        else:
+            sentiment = "neutral"
+
+        items.append(
+            NewsItem(
+                title=headline,
+                summary=summary,
+                source=random.choice(SOURCES),
+                url=f"https://example.com/news/{symbol.lower()}-{i}",
+                published_at=published.isoformat(),
+                relevance_score=relevance,
+                sentiment=sentiment,
+            )
+        )
+
+    # Sort by relevance score descending
+    items.sort(key=lambda x: x.relevance_score, reverse=True)
+
+    return items
+
+
+# ============================================================================
+# Relevance Scoring
+# ============================================================================
+
+
+def calculate_relevance_score(
+    title: str,
+    summary: str,
+    query: str,
+    symbols: list[str],
+) -> float:
+    """Calculate relevance score for a news item.
+
+    Args:
+        title: News title.
+        summary: News summary.
+        query: Original search query.
+        symbols: Stock symbols to match.
+
+    Returns:
+        Relevance score between 0.0 and 1.0.
+    """
+    score = 0.0
+    text = f"{title} {summary}".lower()
+    query_lower = query.lower()
+
+    # Query word matches (up to 0.4)
+    query_words = query_lower.split()
+    matches = sum(1 for word in query_words if word in text)
+    query_score = min(matches / max(len(query_words), 1), 1.0) * 0.4
+    score += query_score
+
+    # Symbol matches (up to 0.4)
+    symbol_matches = sum(1 for symbol in symbols if symbol.lower() in text or symbol.upper() in text)
+    symbol_score = min(symbol_matches / max(len(symbols), 1), 1.0) * 0.4
+    score += symbol_score
+
+    # Financial keyword boost (up to 0.2)
+    financial_keywords = [
+        "stock",
+        "shares",
+        "market",
+        "earnings",
+        "revenue",
+        "profit",
+        "investor",
+        "trading",
+        "analyst",
+        "dividend",
+    ]
+    keyword_matches = sum(1 for kw in financial_keywords if kw in text)
+    keyword_score = min(keyword_matches / 5, 1.0) * 0.2
+    score += keyword_score
+
+    return round(min(score, 1.0), 2)
+
+
+# ============================================================================
+# Google News RSS Parser
+# ============================================================================
+
+
+def parse_google_news_rss(xml_content: str, query: str, symbols: list[str]) -> list[NewsItem]:
+    """Parse Google News RSS feed XML.
+
+    Args:
+        xml_content: Raw XML content from Google News RSS.
+        query: Original search query.
+        symbols: Stock symbols for relevance scoring.
+
+    Returns:
+        List of parsed news items.
+    """
+    items: list[NewsItem] = []
+
+    try:
+        root = ET.fromstring(xml_content)
+        channel = root.find("channel")
+        if channel is None:
+            return items
+
+        for item in channel.findall("item"):
+            title_elem = item.find("title")
+            link_elem = item.find("link")
+            pub_date_elem = item.find("pubDate")
+            source_elem = item.find("source")
+            description_elem = item.find("description")
+
+            if title_elem is None or link_elem is None:
+                continue
+
+            title = title_elem.text or ""
+            url = link_elem.text or ""
+            source = source_elem.text or "Unknown" if source_elem is not None else "Unknown"
+
+            # Parse publication date
+            pub_date_str = pub_date_elem.text if pub_date_elem is not None else None
+            if pub_date_str:
+                try:
+                    # Parse RFC 2822 date format
+                    published_at = _parse_rfc2822_date(pub_date_str)
+                except ValueError:
+                    published_at = datetime.now(UTC)
+            else:
+                published_at = datetime.now(UTC)
+
+            # Extract summary from description (strip HTML)
+            description = description_elem.text if description_elem is not None else ""
+            summary = _strip_html(description)[:500] if description else title
+
+            # Calculate relevance
+            relevance = calculate_relevance_score(title, summary, query, symbols)
+
+            # Determine sentiment
+            sentiment = _analyze_sentiment(title)
+
+            items.append(
+                NewsItem(
+                    title=title,
+                    summary=summary,
+                    source=source,
+                    url=url,
+                    published_at=published_at.isoformat(),
+                    relevance_score=relevance,
+                    sentiment=sentiment,
+                )
+            )
+
+    except ET.ParseError as e:
+        logger.warning("xml_parse_error", error=str(e))
+
+    return items
+
+
+def _parse_rfc2822_date(date_str: str) -> datetime:
+    """Parse RFC 2822 date format.
+
+    Args:
+        date_str: Date string in RFC 2822 format.
+
+    Returns:
+        Parsed datetime.
+    """
+    # Try common formats
+    formats = [
+        "%a, %d %b %Y %H:%M:%S %z",
+        "%a, %d %b %Y %H:%M:%S GMT",
+        "%Y-%m-%dT%H:%M:%SZ",
+    ]
+
+    for fmt in formats:
+        try:
+            return datetime.strptime(date_str, fmt).replace(tzinfo=UTC)
+        except ValueError:
+            continue
+
+    # Default to now if parsing fails
+    return datetime.now(UTC)
+
+
+def _strip_html(html: str) -> str:
+    """Strip HTML tags from a string.
+
+    Args:
+        html: HTML string.
+
+    Returns:
+        Plain text string.
+    """
+    return re.sub(r"<[^>]+>", "", html).strip()
+
+
+def _analyze_sentiment(text: str) -> Literal["positive", "negative", "neutral"]:
+    """Simple sentiment analysis based on keywords.
+
+    Args:
+        text: Text to analyze.
+
+    Returns:
+        Sentiment classification.
+    """
+    text_lower = text.lower()
+
+    positive_words = [
+        "surge",
+        "rally",
+        "jump",
+        "rise",
+        "gain",
+        "beat",
+        "bullish",
+        "optimistic",
+        "growth",
+        "profit",
+        "success",
+        "record",
+        "upgrade",
+    ]
+    negative_words = [
+        "drop",
+        "tumble",
+        "fall",
+        "slide",
+        "sink",
+        "bearish",
+        "disappointing",
+        "loss",
+        "decline",
+        "downgrade",
+        "crash",
+        "plunge",
+        "miss",
+    ]
+
+    positive_count = sum(1 for word in positive_words if word in text_lower)
+    negative_count = sum(1 for word in negative_words if word in text_lower)
+
+    if positive_count > negative_count:
+        return "positive"
+    elif negative_count > positive_count:
+        return "negative"
+    return "neutral"
+
+
+# ============================================================================
+# News Search Tool
+# ============================================================================
+
+
+class NewsSearchTool(BaseTool[NewsSearchInput, NewsSearchOutput]):
+    """Tool for searching financial news.
+
+    Features:
+    - Real-time news via Google News RSS
+    - Mock news generator for testing
+    - Relevance scoring based on query and symbols
+    - Date filtering
+    - Sentiment analysis
+    """
+
+    name = "search_news"
+    description = (
+        "Searches for recent financial news related to a query or stock symbols. "
+        "Returns relevant news items with titles, summaries, and relevance scores."
+    )
+
+    GOOGLE_NEWS_RSS_URL = "https://news.google.com/rss/search"
+
+    def __init__(
+        self,
+        use_mock: bool | None = None,
+        fallback_to_mock: bool | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        """Initialize the NewsSearchTool.
+
+        Args:
+            use_mock: Whether to use mock data instead of real API.
+            fallback_to_mock: Whether to fall back to mock on API failure.
+            http_client: Optional custom HTTP client.
+        """
+        super().__init__(use_mock=use_mock, fallback_to_mock=fallback_to_mock)
+        self._http_client = http_client
+
+    @property
+    def input_schema(self) -> type[NewsSearchInput]:
+        return NewsSearchInput
+
+    @property
+    def output_schema(self) -> type[NewsSearchOutput]:
+        return NewsSearchOutput
+
+    async def _get_http_client(self) -> httpx.AsyncClient:
+        """Get or create HTTP client."""
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(timeout=30.0)
+        return self._http_client
+
+    async def _execute_real(self, input_data: NewsSearchInput) -> NewsSearchOutput:
+        """Fetch real news from Google News RSS.
+
+        Args:
+            input_data: Validated input with query and filters.
+
+        Returns:
+            News search output.
+
+        Raises:
+            ValueError: If the search fails.
+        """
+        # Build search query
+        search_terms = [input_data.query]
+        if input_data.symbols:
+            search_terms.extend(input_data.symbols)
+        full_query = " ".join(search_terms)
+
+        self._logger.info("searching_news", query=full_query)
+
+        # Fetch from Google News RSS
+        client = await self._get_http_client()
+        url = f"{self.GOOGLE_NEWS_RSS_URL}?q={quote(full_query)}&hl=en-US&gl=US&ceid=US:en"
+
+        try:
+            response = await client.get(url)
+            response.raise_for_status()
+        except httpx.HTTPError as e:
+            raise ValueError(f"Failed to fetch news: {e}") from e
+
+        # Parse RSS feed
+        items = parse_google_news_rss(
+            response.text,
+            input_data.query,
+            input_data.symbols,
+        )
+
+        # Filter by date
+        cutoff = datetime.now(UTC) - timedelta(days=input_data.days_back)
+        filtered_items: list[NewsItem] = []
+        for item in items:
+            try:
+                pub_date = datetime.fromisoformat(item.published_at.replace("Z", "+00:00"))
+                if pub_date >= cutoff:
+                    filtered_items.append(item)
+            except ValueError:
+                # Include items with unparseable dates
+                filtered_items.append(item)
+
+        # Sort by relevance and limit
+        filtered_items.sort(key=lambda x: x.relevance_score, reverse=True)
+        result_items = filtered_items[: input_data.max_results]
+
+        return NewsSearchOutput(
+            query=input_data.query,
+            items=result_items,
+            total_found=len(items),
+            source="real",
+        )
+
+    async def _execute_mock(self, input_data: NewsSearchInput) -> NewsSearchOutput:
+        """Return mock news data.
+
+        Args:
+            input_data: Validated input with query and filters.
+
+        Returns:
+            Mock news search output.
+        """
+        items = generate_mock_news(
+            query=input_data.query,
+            symbols=input_data.symbols,
+            days_back=input_data.days_back,
+            max_results=input_data.max_results,
+        )
+
+        return NewsSearchOutput(
+            query=input_data.query,
+            items=items,
+            total_found=len(items),
+            source="mock",
+        )
+
+    async def close(self) -> None:
+        """Close HTTP client."""
+        if self._http_client:
+            await self._http_client.aclose()
+            self._http_client = None

--- a/tests/test_tools/test_news_search.py
+++ b/tests/test_tools/test_news_search.py
@@ -1,0 +1,543 @@
+"""Tests for the News Search Tool."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from src.tools.base import ToolExecutionError
+from src.tools.news_search import (
+    NewsItem,
+    NewsSearchInput,
+    NewsSearchOutput,
+    NewsSearchTool,
+    calculate_relevance_score,
+    generate_mock_news,
+    parse_google_news_rss,
+)
+
+
+class TestNewsSearchInput:
+    """Tests for NewsSearchInput model."""
+
+    def test_required_fields(self) -> None:
+        """Test that query is required."""
+        input_data = NewsSearchInput(query="AAPL stock")
+        assert input_data.query == "AAPL stock"
+        assert input_data.symbols == []
+        assert input_data.days_back == 7
+        assert input_data.max_results == 10
+
+    def test_all_fields(self) -> None:
+        """Test with all fields provided."""
+        input_data = NewsSearchInput(
+            query="tech stocks",
+            symbols=["AAPL", "GOOGL"],
+            days_back=14,
+            max_results=20,
+        )
+        assert input_data.symbols == ["AAPL", "GOOGL"]
+        assert input_data.days_back == 14
+        assert input_data.max_results == 20
+
+    def test_days_back_validation(self) -> None:
+        """Test days_back range validation."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            NewsSearchInput(query="test", days_back=0)
+
+        with pytest.raises(ValidationError):
+            NewsSearchInput(query="test", days_back=31)
+
+    def test_max_results_validation(self) -> None:
+        """Test max_results range validation."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            NewsSearchInput(query="test", max_results=0)
+
+        with pytest.raises(ValidationError):
+            NewsSearchInput(query="test", max_results=51)
+
+
+class TestNewsItem:
+    """Tests for NewsItem model."""
+
+    def test_required_fields(self) -> None:
+        """Test required fields."""
+        item = NewsItem(
+            title="Test News",
+            summary="Test summary",
+            source="Reuters",
+            url="https://example.com",
+            published_at="2024-01-15T10:00:00Z",
+            relevance_score=0.8,
+        )
+        assert item.title == "Test News"
+        assert item.relevance_score == 0.8
+        assert item.sentiment is None
+
+    def test_with_sentiment(self) -> None:
+        """Test with sentiment field."""
+        item = NewsItem(
+            title="Test News",
+            summary="Test summary",
+            source="Reuters",
+            url="https://example.com",
+            published_at="2024-01-15T10:00:00Z",
+            relevance_score=0.8,
+            sentiment="positive",
+        )
+        assert item.sentiment == "positive"
+
+    def test_relevance_score_validation(self) -> None:
+        """Test relevance_score range validation."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            NewsItem(
+                title="Test",
+                summary="Test",
+                source="Test",
+                url="https://example.com",
+                published_at="2024-01-15T10:00:00Z",
+                relevance_score=1.5,
+            )
+
+
+class TestNewsSearchOutput:
+    """Tests for NewsSearchOutput model."""
+
+    def test_default_values(self) -> None:
+        """Test default values."""
+        output = NewsSearchOutput(query="test", source="mock")
+        assert output.items == []
+        assert output.total_found == 0
+        assert output.success is True
+
+    def test_with_items(self) -> None:
+        """Test with items."""
+        item = NewsItem(
+            title="Test",
+            summary="Summary",
+            source="Reuters",
+            url="https://example.com",
+            published_at="2024-01-15T10:00:00Z",
+            relevance_score=0.8,
+        )
+        output = NewsSearchOutput(
+            query="test",
+            items=[item],
+            total_found=1,
+            source="real",
+        )
+        assert len(output.items) == 1
+        assert output.source == "real"
+
+
+class TestRelevanceScoring:
+    """Tests for relevance scoring."""
+
+    def test_query_word_matching(self) -> None:
+        """Test relevance score from query word matches."""
+        score = calculate_relevance_score(
+            title="Apple stock rises on earnings",
+            summary="Apple reported strong earnings today",
+            query="apple earnings",
+            symbols=[],
+        )
+        assert score > 0.3  # Should have query word matches
+
+    def test_symbol_matching(self) -> None:
+        """Test relevance score from symbol matches."""
+        score = calculate_relevance_score(
+            title="AAPL surges after product launch",
+            summary="Apple Inc AAPL stock rises",
+            query="stock news",
+            symbols=["AAPL"],
+        )
+        assert score > 0.3  # Should have symbol matches
+
+    def test_financial_keyword_boost(self) -> None:
+        """Test relevance boost from financial keywords."""
+        score = calculate_relevance_score(
+            title="Stock market trading update on earnings and revenue",
+            summary="Investors monitor analyst predictions for dividend announcement",
+            query="",
+            symbols=[],
+        )
+        assert score > 0.1  # Should have keyword boost
+
+    def test_combined_scoring(self) -> None:
+        """Test combined relevance scoring."""
+        score = calculate_relevance_score(
+            title="AAPL stock earnings beat expectations",
+            summary="Apple AAPL shares surge after analyst upgrade",
+            query="apple earnings",
+            symbols=["AAPL"],
+        )
+        assert score > 0.5  # Should have high combined score
+
+    def test_no_matches(self) -> None:
+        """Test relevance score with no matches."""
+        score = calculate_relevance_score(
+            title="Weather forecast for tomorrow",
+            summary="Rain expected in the afternoon",
+            query="apple stock",
+            symbols=["AAPL"],
+        )
+        assert score < 0.2  # Should have low score
+
+
+class TestMockNewsGenerator:
+    """Tests for mock news generation."""
+
+    def test_generates_correct_count(self) -> None:
+        """Test that generator produces correct number of items."""
+        items = generate_mock_news(
+            query="AAPL",
+            symbols=["AAPL", "GOOGL"],
+            days_back=7,
+            max_results=5,
+        )
+        assert len(items) == 5
+
+    def test_items_have_required_fields(self) -> None:
+        """Test that generated items have all required fields."""
+        items = generate_mock_news(
+            query="tech stocks",
+            symbols=["MSFT"],
+            days_back=7,
+            max_results=3,
+        )
+
+        for item in items:
+            assert item.title
+            assert item.summary
+            assert item.source
+            assert item.url
+            assert item.published_at
+            assert 0.0 <= item.relevance_score <= 1.0
+            assert item.sentiment in ["positive", "negative", "neutral"]
+
+    def test_dates_within_range(self) -> None:
+        """Test that generated dates are within specified range."""
+        days_back = 7
+        items = generate_mock_news(
+            query="test",
+            symbols=[],
+            days_back=days_back,
+            max_results=10,
+        )
+
+        cutoff = datetime.now(UTC) - timedelta(days=days_back)
+        for item in items:
+            pub_date = datetime.fromisoformat(item.published_at)
+            assert pub_date >= cutoff
+
+    def test_sorted_by_relevance(self) -> None:
+        """Test that items are sorted by relevance score."""
+        items = generate_mock_news(
+            query="AAPL",
+            symbols=["AAPL"],
+            days_back=7,
+            max_results=10,
+        )
+
+        scores = [item.relevance_score for item in items]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_uses_symbols_in_headlines(self) -> None:
+        """Test that symbols appear in generated headlines."""
+        items = generate_mock_news(
+            query="tech",
+            symbols=["AAPL"],
+            days_back=7,
+            max_results=5,
+        )
+
+        # At least one item should mention AAPL
+        has_symbol = any("AAPL" in item.title for item in items)
+        assert has_symbol
+
+
+class TestGoogleNewsRSSParser:
+    """Tests for Google News RSS parsing."""
+
+    def test_parse_valid_rss(self) -> None:
+        """Test parsing valid RSS feed."""
+        rss_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+                <title>Google News</title>
+                <item>
+                    <title>AAPL stock rises on earnings</title>
+                    <link>https://example.com/news/1</link>
+                    <pubDate>Mon, 15 Jan 2024 10:00:00 GMT</pubDate>
+                    <source>Reuters</source>
+                    <description>Apple stock increased after strong earnings report.</description>
+                </item>
+            </channel>
+        </rss>"""
+
+        items = parse_google_news_rss(rss_content, "AAPL", ["AAPL"])
+
+        assert len(items) == 1
+        assert items[0].title == "AAPL stock rises on earnings"
+        assert items[0].source == "Reuters"
+        assert items[0].url == "https://example.com/news/1"
+
+    def test_parse_multiple_items(self) -> None:
+        """Test parsing multiple items."""
+        rss_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <title>News 1</title>
+                    <link>https://example.com/1</link>
+                </item>
+                <item>
+                    <title>News 2</title>
+                    <link>https://example.com/2</link>
+                </item>
+            </channel>
+        </rss>"""
+
+        items = parse_google_news_rss(rss_content, "test", [])
+        assert len(items) == 2
+
+    def test_parse_empty_feed(self) -> None:
+        """Test parsing empty feed."""
+        rss_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+                <title>Google News</title>
+            </channel>
+        </rss>"""
+
+        items = parse_google_news_rss(rss_content, "test", [])
+        assert len(items) == 0
+
+    def test_parse_invalid_xml(self) -> None:
+        """Test handling invalid XML."""
+        items = parse_google_news_rss("not valid xml", "test", [])
+        assert len(items) == 0
+
+    def test_parse_missing_required_fields(self) -> None:
+        """Test that items without title/link are skipped."""
+        rss_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <description>No title or link</description>
+                </item>
+            </channel>
+        </rss>"""
+
+        items = parse_google_news_rss(rss_content, "test", [])
+        assert len(items) == 0
+
+
+class TestNewsSearchTool:
+    """Tests for NewsSearchTool."""
+
+    def test_tool_properties(self) -> None:
+        """Test tool has correct name and description."""
+        tool = NewsSearchTool()
+        assert tool.name == "search_news"
+        assert "news" in tool.description.lower()
+
+    def test_to_anthropic_tool(self) -> None:
+        """Test conversion to Anthropic tool format."""
+        tool = NewsSearchTool()
+        anthropic_tool = tool.to_anthropic_tool()
+
+        assert anthropic_tool["name"] == "search_news"
+        assert "query" in anthropic_tool["input_schema"]["properties"]
+        assert "symbols" in anthropic_tool["input_schema"]["properties"]
+
+    @pytest.mark.asyncio
+    async def test_execute_mock(self) -> None:
+        """Test mock execution."""
+        tool = NewsSearchTool(use_mock=True)
+        result = await tool.execute({
+            "query": "AAPL stock",
+            "symbols": ["AAPL"],
+            "max_results": 5,
+        })
+
+        assert result.query == "AAPL stock"
+        assert len(result.items) == 5
+        assert result.source == "mock"
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_execute_mock_respects_max_results(self) -> None:
+        """Test that mock respects max_results."""
+        tool = NewsSearchTool(use_mock=True)
+        result = await tool.execute({
+            "query": "tech stocks",
+            "max_results": 3,
+        })
+
+        assert len(result.items) == 3
+
+    @pytest.mark.asyncio
+    async def test_execute_real_success(self) -> None:
+        """Test real execution with mocked HTTP response."""
+        mock_rss = """<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <title>AAPL stock news</title>
+                    <link>https://example.com/1</link>
+                    <source>Reuters</source>
+                </item>
+            </channel>
+        </rss>"""
+
+        mock_response = AsyncMock()
+        mock_response.text = mock_rss
+        mock_response.raise_for_status.return_value = None
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = mock_response
+
+        tool = NewsSearchTool(use_mock=False, http_client=mock_client)
+        result = await tool.execute({"query": "AAPL"})
+
+        assert result.source == "real"
+        assert len(result.items) >= 0  # May have items if parsed correctly
+        mock_client.get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_real_failure_fallback(self) -> None:
+        """Test fallback to mock when real API fails."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = httpx.HTTPError("Connection failed")
+
+        tool = NewsSearchTool(
+            use_mock=False,
+            fallback_to_mock=True,
+            http_client=mock_client,
+        )
+        result = await tool.execute({"query": "AAPL"})
+
+        assert result.source == "mock"
+        assert "Fallback" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_execute_real_failure_no_fallback(self) -> None:
+        """Test error raised when fallback disabled."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = httpx.HTTPError("Connection failed")
+
+        tool = NewsSearchTool(
+            use_mock=False,
+            fallback_to_mock=False,
+            http_client=mock_client,
+        )
+
+        with pytest.raises(ToolExecutionError):
+            await tool.execute({"query": "AAPL"})
+
+    @pytest.mark.asyncio
+    async def test_date_filtering(self) -> None:
+        """Test that results are filtered by date."""
+        # Create RSS with items at different dates
+        now = datetime.now(UTC)
+        old_date = (now - timedelta(days=30)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+        recent_date = (now - timedelta(days=1)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+        mock_rss = f"""<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <title>Old news</title>
+                    <link>https://example.com/old</link>
+                    <pubDate>{old_date}</pubDate>
+                </item>
+                <item>
+                    <title>Recent news</title>
+                    <link>https://example.com/recent</link>
+                    <pubDate>{recent_date}</pubDate>
+                </item>
+            </channel>
+        </rss>"""
+
+        mock_response = AsyncMock()
+        mock_response.text = mock_rss
+        mock_response.raise_for_status.return_value = None
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = mock_response
+
+        tool = NewsSearchTool(use_mock=False, http_client=mock_client)
+        result = await tool.execute({
+            "query": "test",
+            "days_back": 7,
+        })
+
+        # Only recent news should be included
+        assert len(result.items) == 1
+        assert "Recent" in result.items[0].title
+
+    @pytest.mark.asyncio
+    async def test_close(self) -> None:
+        """Test closing HTTP client."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        tool = NewsSearchTool(http_client=mock_client)
+
+        await tool.close()
+
+        mock_client.aclose.assert_called_once()
+        assert tool._http_client is None
+
+
+class TestSentimentAnalysis:
+    """Tests for sentiment analysis."""
+
+    def test_positive_sentiment(self) -> None:
+        """Test detection of positive sentiment."""
+        from src.tools.news_search import _analyze_sentiment
+
+        assert _analyze_sentiment("Stock surges after earnings beat") == "positive"
+        assert _analyze_sentiment("Company reports record growth") == "positive"
+
+    def test_negative_sentiment(self) -> None:
+        """Test detection of negative sentiment."""
+        from src.tools.news_search import _analyze_sentiment
+
+        assert _analyze_sentiment("Stock plunges on disappointing results") == "negative"
+        assert _analyze_sentiment("Shares crash after downgrade") == "negative"
+
+    def test_neutral_sentiment(self) -> None:
+        """Test detection of neutral sentiment."""
+        from src.tools.news_search import _analyze_sentiment
+
+        assert _analyze_sentiment("Company announces new product") == "neutral"
+        assert _analyze_sentiment("CEO speaks at conference") == "neutral"
+
+
+class TestInputValidation:
+    """Tests for input validation."""
+
+    @pytest.mark.asyncio
+    async def test_missing_query(self) -> None:
+        """Test that missing query raises error."""
+        tool = NewsSearchTool(use_mock=True)
+
+        with pytest.raises(ToolExecutionError, match="Input validation failed"):
+            await tool.execute({})
+
+    @pytest.mark.asyncio
+    async def test_accepts_model_input(self) -> None:
+        """Test that validated model can be passed directly."""
+        tool = NewsSearchTool(use_mock=True)
+        input_data = NewsSearchInput(query="AAPL stock")
+
+        result = await tool.execute(input_data)
+
+        assert result.query == "AAPL stock"


### PR DESCRIPTION
## Summary
- Implements NewsSearchTool for fetching financial news from Google News RSS
- Includes mock news generator with realistic headline templates for testing/resilience
- Features relevance scoring algorithm combining query matching, symbol matching, and financial keyword boosting
- Adds date filtering and sentiment analysis capabilities
- 38 comprehensive unit tests covering all functionality

## Implementation Details
- **NewsSearchInput**: Query, symbols, days_back, max_results parameters
- **NewsItem**: Title, summary, source, URL, published_at, relevance_score, sentiment
- **NewsSearchOutput**: Query, items list, total_found, source (real/mock)
- **Mock Generator**: 10 headline templates with realistic financial vocabulary
- **Relevance Scoring**: Query word matching (0.4), symbol matching (0.4), financial keywords (0.2)
- **RSS Parser**: Google News RSS feed parsing with date and sentiment extraction

## Test Plan
- [x] Input/Output schema validation tests
- [x] Mock news generation tests
- [x] Relevance scoring algorithm tests
- [x] Google News RSS parsing tests
- [x] Tool execution tests (mock and real modes)
- [x] Sentiment analysis tests
- [x] Date filtering tests
- [x] All 150 tests passing

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)