### PR TITLE
feat: Define state schema and agent communication contracts (#18)

### DIFF
--- a/src/orchestration/__init__.py
+++ b/src/orchestration/__init__.py
@@ -5,3 +5,49 @@ This module contains:
 - State management
 - Error handling and recovery
 """
+
+from src.orchestration.state import (
+    AgentName,
+    AnalysisOutputDict,
+    Portfolio,
+    PortfolioState,
+    Position,
+    RecommendationOutputDict,
+    ResearchOutputDict,
+    StatePersistence,
+    StateValidationError,
+    WorkflowStatus,
+    create_initial_state,
+    get_state_summary,
+    mark_state_completed,
+    mark_state_failed,
+    state_from_json,
+    state_to_json,
+    update_state_for_agent,
+    update_state_with_result,
+    validate_state,
+    validate_state_or_raise,
+)
+
+__all__ = [
+    "AgentName",
+    "AnalysisOutputDict",
+    "Portfolio",
+    "PortfolioState",
+    "Position",
+    "RecommendationOutputDict",
+    "ResearchOutputDict",
+    "StatePersistence",
+    "StateValidationError",
+    "WorkflowStatus",
+    "create_initial_state",
+    "get_state_summary",
+    "mark_state_completed",
+    "mark_state_failed",
+    "state_from_json",
+    "state_to_json",
+    "update_state_for_agent",
+    "update_state_with_result",
+    "validate_state",
+    "validate_state_or_raise",
+]

--- a/src/orchestration/state.py
+++ b/src/orchestration/state.py
@@ -1,0 +1,761 @@
+"""State schema and management for multi-agent workflow.
+
+This module defines the state that flows through the portfolio advisor workflow,
+including input/output contracts for each agent and state persistence.
+"""
+
+import json
+import uuid
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any, TypedDict
+
+import structlog
+from pydantic import BaseModel, Field, field_validator
+
+logger = structlog.get_logger(__name__)
+
+
+# ============================================================================
+# Enums
+# ============================================================================
+
+
+class WorkflowStatus(str, Enum):
+    """Status of the workflow execution."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class AgentName(str, Enum):
+    """Names of agents in the workflow."""
+
+    RESEARCH = "research"
+    ANALYSIS = "analysis"
+    RECOMMENDATION = "recommendation"
+
+
+# ============================================================================
+# Portfolio Input Schema
+# ============================================================================
+
+
+class Position(BaseModel):
+    """A single portfolio position."""
+
+    symbol: str = Field(..., description="Stock ticker symbol")
+    quantity: float = Field(..., description="Number of shares held")
+    cost_basis: float | None = Field(default=None, description="Average cost per share")
+    current_price: float | None = Field(default=None, description="Current market price")
+    market_value: float | None = Field(default=None, description="Current market value")
+    weight: float | None = Field(default=None, description="Portfolio weight (0-1)")
+    sector: str | None = Field(default=None, description="Sector classification")
+
+
+class Portfolio(BaseModel):
+    """Portfolio representation for workflow input."""
+
+    positions: list[Position] = Field(default_factory=list)
+    total_value: float = Field(default=0.0, description="Total portfolio value")
+    cash: float = Field(default=0.0, description="Cash balance")
+    account_type: str = Field(default="taxable", description="Account type")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @field_validator("positions", mode="before")
+    @classmethod
+    def parse_positions(cls, v: Any) -> list[Position]:
+        """Parse positions from various formats."""
+        if not v:
+            return []
+        if isinstance(v, list):
+            result: list[Position] = [
+                Position(**p) if isinstance(p, dict) else p for p in v
+            ]
+            return result
+        # If not a list, return empty (Pydantic will validate further)
+        return []
+
+    @property
+    def symbols(self) -> list[str]:
+        """Get list of symbols in portfolio."""
+        return [p.symbol for p in self.positions]
+
+    def get_weights(self) -> dict[str, float]:
+        """Calculate portfolio weights."""
+        if self.total_value <= 0:
+            return {}
+        return {
+            p.symbol: (p.market_value or 0) / self.total_value
+            for p in self.positions
+            if p.market_value
+        }
+
+
+# ============================================================================
+# Agent Output TypedDicts (for type hints in state)
+# ============================================================================
+
+
+class ResearchOutputDict(TypedDict, total=False):
+    """TypedDict representation of ResearchAgent output."""
+
+    market_data: dict[str, Any]
+    news: list[dict[str, Any]]
+    summary: str
+    symbols_researched: list[str]
+    data_freshness: str
+    errors: list[str]
+
+
+class AnalysisOutputDict(TypedDict, total=False):
+    """TypedDict representation of AnalysisAgent output."""
+
+    risk_metrics: dict[str, Any]
+    correlations: dict[str, Any]
+    benchmark_comparison: dict[str, Any]
+    attribution: dict[str, Any]
+    recommendations: list[str]
+    summary: str
+    errors: list[str]
+
+
+class RecommendationOutputDict(TypedDict, total=False):
+    """TypedDict representation of RecommendationAgent output."""
+
+    trades: list[dict[str, Any]]
+    tax_impact: dict[str, Any]
+    execution_costs: dict[str, Any]
+    compliance: dict[str, Any]
+    summary: str
+    total_trades: int
+    buy_count: int
+    sell_count: int
+    hold_count: int
+    errors: list[str]
+
+
+# ============================================================================
+# Workflow State Schema
+# ============================================================================
+
+
+class PortfolioState(TypedDict, total=False):
+    """State that flows through the multi-agent workflow.
+
+    This state is passed between agents and accumulates results from each step.
+    Uses TypedDict for LangGraph compatibility.
+
+    Flow:
+        Request → State.portfolio, State.user_request
+                ↓
+        Research Agent → State.research (populated)
+                ↓
+        Analysis Agent ← reads State.research
+                      → State.analysis (populated)
+                ↓
+        Recommendation Agent ← reads State.research, State.analysis
+                            → State.recommendation (populated)
+                ↓
+        Response ← State.recommendation
+    """
+
+    # Identifiers
+    workflow_id: str
+    trace_id: str
+    user_id: str | None
+
+    # Input
+    portfolio: dict[str, Any]  # Serialized Portfolio
+    user_request: str
+    symbols: list[str]
+
+    # Agent outputs (populated as workflow progresses)
+    research: ResearchOutputDict | None
+    analysis: AnalysisOutputDict | None
+    recommendation: RecommendationOutputDict | None
+
+    # Workflow metadata
+    status: str  # WorkflowStatus value
+    current_agent: str | None  # AgentName value
+    started_at: str  # ISO format datetime
+    completed_at: str | None
+    error: str | None
+
+    # Accumulated messages and errors
+    messages: list[dict[str, Any]]
+    errors: list[str]
+
+    # Context for passing additional data
+    context: dict[str, Any]
+
+
+# ============================================================================
+# State Factory and Helpers
+# ============================================================================
+
+
+def create_initial_state(
+    portfolio: Portfolio | dict[str, Any],
+    user_request: str,
+    user_id: str | None = None,
+    trace_id: str | None = None,
+) -> PortfolioState:
+    """Create an initial workflow state.
+
+    Args:
+        portfolio: Portfolio data (model or dict).
+        user_request: User's request/query.
+        user_id: Optional user identifier.
+        trace_id: Optional trace ID for observability.
+
+    Returns:
+        Initial PortfolioState ready for workflow execution.
+    """
+    workflow_id = str(uuid.uuid4())
+    trace_id = trace_id or str(uuid.uuid4())
+
+    # Convert portfolio to dict if needed
+    if isinstance(portfolio, Portfolio):
+        portfolio_dict = portfolio.model_dump(mode="json")
+        symbols = portfolio.symbols
+    else:
+        portfolio_dict = portfolio
+        symbols = [p.get("symbol", "") for p in portfolio.get("positions", [])]
+
+    state: PortfolioState = {
+        "workflow_id": workflow_id,
+        "trace_id": trace_id,
+        "user_id": user_id,
+        "portfolio": portfolio_dict,
+        "user_request": user_request,
+        "symbols": symbols,
+        "research": None,
+        "analysis": None,
+        "recommendation": None,
+        "status": WorkflowStatus.PENDING.value,
+        "current_agent": None,
+        "started_at": datetime.now(UTC).isoformat(),
+        "completed_at": None,
+        "error": None,
+        "messages": [],
+        "errors": [],
+        "context": {},
+    }
+
+    logger.info(
+        "initial_state_created",
+        workflow_id=workflow_id,
+        trace_id=trace_id,
+        symbol_count=len(symbols),
+    )
+
+    return state
+
+
+def update_state_for_agent(
+    state: PortfolioState,
+    agent: AgentName,
+) -> PortfolioState:
+    """Update state when entering an agent.
+
+    Args:
+        state: Current workflow state.
+        agent: Agent being entered.
+
+    Returns:
+        Updated state.
+    """
+    state["current_agent"] = agent.value
+    state["status"] = WorkflowStatus.RUNNING.value
+    return state
+
+
+def update_state_with_result(
+    state: PortfolioState,
+    agent: AgentName,
+    result: dict[str, Any],
+) -> PortfolioState:
+    """Update state with agent result.
+
+    Args:
+        state: Current workflow state.
+        agent: Agent that produced the result.
+        result: Agent output.
+
+    Returns:
+        Updated state.
+    """
+    if agent == AgentName.RESEARCH:
+        state["research"] = result  # type: ignore[typeddict-item]
+    elif agent == AgentName.ANALYSIS:
+        state["analysis"] = result  # type: ignore[typeddict-item]
+    elif agent == AgentName.RECOMMENDATION:
+        state["recommendation"] = result  # type: ignore[typeddict-item]
+
+    # Check for errors in result
+    if result.get("errors"):
+        state["errors"].extend(result["errors"])
+
+    return state
+
+
+def mark_state_completed(state: PortfolioState) -> PortfolioState:
+    """Mark state as completed.
+
+    Args:
+        state: Current workflow state.
+
+    Returns:
+        Updated state.
+    """
+    state["status"] = WorkflowStatus.COMPLETED.value
+    state["completed_at"] = datetime.now(UTC).isoformat()
+    state["current_agent"] = None
+    return state
+
+
+def mark_state_failed(state: PortfolioState, error: str) -> PortfolioState:
+    """Mark state as failed.
+
+    Args:
+        state: Current workflow state.
+        error: Error message.
+
+    Returns:
+        Updated state.
+    """
+    state["status"] = WorkflowStatus.FAILED.value
+    state["completed_at"] = datetime.now(UTC).isoformat()
+    state["error"] = error
+    state["errors"].append(error)
+    return state
+
+
+# ============================================================================
+# State Validation
+# ============================================================================
+
+
+class StateValidationError(Exception):
+    """Raised when state validation fails."""
+
+    pass
+
+
+def validate_state(state: PortfolioState) -> list[str]:
+    """Validate workflow state.
+
+    Args:
+        state: State to validate.
+
+    Returns:
+        List of validation errors (empty if valid).
+    """
+    errors: list[str] = []
+
+    # Required fields
+    if not state.get("workflow_id"):
+        errors.append("Missing workflow_id")
+    if not state.get("trace_id"):
+        errors.append("Missing trace_id")
+    if not state.get("portfolio"):
+        errors.append("Missing portfolio")
+    if not state.get("user_request"):
+        errors.append("Missing user_request")
+
+    # Status must be valid
+    status = state.get("status")
+    if status and status not in [s.value for s in WorkflowStatus]:
+        errors.append(f"Invalid status: {status}")
+
+    # Current agent must be valid if set
+    current_agent = state.get("current_agent")
+    if current_agent and current_agent not in [a.value for a in AgentName]:
+        errors.append(f"Invalid current_agent: {current_agent}")
+
+    # Timestamps must be parseable
+    started_at = state.get("started_at")
+    if started_at:
+        try:
+            datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            errors.append(f"Invalid started_at format: {started_at}")
+
+    completed_at = state.get("completed_at")
+    if completed_at:
+        try:
+            datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            errors.append(f"Invalid completed_at format: {completed_at}")
+
+    return errors
+
+
+def validate_state_or_raise(state: PortfolioState) -> None:
+    """Validate state and raise if invalid.
+
+    Args:
+        state: State to validate.
+
+    Raises:
+        StateValidationError: If validation fails.
+    """
+    errors = validate_state(state)
+    if errors:
+        raise StateValidationError(f"State validation failed: {'; '.join(errors)}")
+
+
+# ============================================================================
+# State Persistence (PostgreSQL)
+# ============================================================================
+
+
+class StatePersistence:
+    """Handles state persistence to PostgreSQL.
+
+    Uses asyncpg for async database operations.
+    """
+
+    def __init__(self, connection_string: str | None = None) -> None:
+        """Initialize persistence handler.
+
+        Args:
+            connection_string: PostgreSQL connection string.
+                If not provided, uses DATABASE_URL environment variable.
+        """
+        import os
+
+        self.connection_string = connection_string or os.getenv(
+            "DATABASE_URL", "postgresql://localhost:5432/portfolio_advisor"
+        )
+        self._pool: Any = None
+
+    async def _get_pool(self) -> Any:
+        """Get or create connection pool."""
+        if self._pool is None:
+            try:
+                import asyncpg  # type: ignore[import-untyped]
+
+                self._pool = await asyncpg.create_pool(
+                    self.connection_string,
+                    min_size=2,
+                    max_size=10,
+                )
+                logger.info("database_pool_created")
+            except ImportError:
+                logger.warning("asyncpg_not_installed", message="State persistence disabled")
+                raise
+            except Exception as e:
+                logger.error("database_pool_failed", error=str(e))
+                raise
+
+        return self._pool
+
+    async def initialize_schema(self) -> None:
+        """Create the workflow_states table if it doesn't exist."""
+        pool = await self._get_pool()
+
+        create_table_sql = """
+        CREATE TABLE IF NOT EXISTS workflow_states (
+            workflow_id UUID PRIMARY KEY,
+            trace_id UUID NOT NULL,
+            user_id TEXT,
+            portfolio JSONB NOT NULL,
+            user_request TEXT NOT NULL,
+            symbols TEXT[] NOT NULL,
+            research JSONB,
+            analysis JSONB,
+            recommendation JSONB,
+            status TEXT NOT NULL,
+            current_agent TEXT,
+            started_at TIMESTAMPTZ NOT NULL,
+            completed_at TIMESTAMPTZ,
+            error TEXT,
+            messages JSONB NOT NULL DEFAULT '[]'::jsonb,
+            errors TEXT[] NOT NULL DEFAULT '{}',
+            context JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ DEFAULT NOW(),
+            updated_at TIMESTAMPTZ DEFAULT NOW()
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_workflow_states_trace_id ON workflow_states(trace_id);
+        CREATE INDEX IF NOT EXISTS idx_workflow_states_user_id ON workflow_states(user_id);
+        CREATE INDEX IF NOT EXISTS idx_workflow_states_status ON workflow_states(status);
+        CREATE INDEX IF NOT EXISTS idx_workflow_states_started_at ON workflow_states(started_at);
+        """
+
+        async with pool.acquire() as conn:
+            await conn.execute(create_table_sql)
+            logger.info("schema_initialized")
+
+    async def save_state(self, state: PortfolioState) -> None:
+        """Save or update workflow state.
+
+        Args:
+            state: State to save.
+        """
+        validate_state_or_raise(state)
+
+        pool = await self._get_pool()
+
+        upsert_sql = """
+        INSERT INTO workflow_states (
+            workflow_id, trace_id, user_id, portfolio, user_request, symbols,
+            research, analysis, recommendation, status, current_agent,
+            started_at, completed_at, error, messages, errors, context, updated_at
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NOW()
+        )
+        ON CONFLICT (workflow_id) DO UPDATE SET
+            research = EXCLUDED.research,
+            analysis = EXCLUDED.analysis,
+            recommendation = EXCLUDED.recommendation,
+            status = EXCLUDED.status,
+            current_agent = EXCLUDED.current_agent,
+            completed_at = EXCLUDED.completed_at,
+            error = EXCLUDED.error,
+            messages = EXCLUDED.messages,
+            errors = EXCLUDED.errors,
+            context = EXCLUDED.context,
+            updated_at = NOW()
+        """
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                upsert_sql,
+                uuid.UUID(state["workflow_id"]),
+                uuid.UUID(state["trace_id"]),
+                state.get("user_id"),
+                json.dumps(state.get("portfolio", {})),
+                state.get("user_request", ""),
+                state.get("symbols", []),
+                json.dumps(state.get("research")) if state.get("research") else None,
+                json.dumps(state.get("analysis")) if state.get("analysis") else None,
+                json.dumps(state.get("recommendation")) if state.get("recommendation") else None,
+                state.get("status"),
+                state.get("current_agent"),
+                datetime.fromisoformat(state["started_at"].replace("Z", "+00:00")),
+                (
+                    datetime.fromisoformat(completed.replace("Z", "+00:00"))
+                    if (completed := state.get("completed_at"))
+                    else None
+                ),
+                state.get("error"),
+                json.dumps(state.get("messages", [])),
+                state.get("errors", []),
+                json.dumps(state.get("context", {})),
+            )
+
+        logger.debug("state_saved", workflow_id=state["workflow_id"])
+
+    async def load_state(self, workflow_id: str) -> PortfolioState | None:
+        """Load workflow state by ID.
+
+        Args:
+            workflow_id: Workflow identifier.
+
+        Returns:
+            State if found, None otherwise.
+        """
+        pool = await self._get_pool()
+
+        select_sql = """
+        SELECT workflow_id, trace_id, user_id, portfolio, user_request, symbols,
+               research, analysis, recommendation, status, current_agent,
+               started_at, completed_at, error, messages, errors, context
+        FROM workflow_states
+        WHERE workflow_id = $1
+        """
+
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(select_sql, uuid.UUID(workflow_id))
+
+        if not row:
+            return None
+
+        state: PortfolioState = {
+            "workflow_id": str(row["workflow_id"]),
+            "trace_id": str(row["trace_id"]),
+            "user_id": row["user_id"],
+            "portfolio": json.loads(row["portfolio"]),
+            "user_request": row["user_request"],
+            "symbols": list(row["symbols"]),
+            "research": json.loads(row["research"]) if row["research"] else None,
+            "analysis": json.loads(row["analysis"]) if row["analysis"] else None,
+            "recommendation": json.loads(row["recommendation"]) if row["recommendation"] else None,
+            "status": row["status"],
+            "current_agent": row["current_agent"],
+            "started_at": row["started_at"].isoformat(),
+            "completed_at": row["completed_at"].isoformat() if row["completed_at"] else None,
+            "error": row["error"],
+            "messages": json.loads(row["messages"]),
+            "errors": list(row["errors"]),
+            "context": json.loads(row["context"]),
+        }
+
+        logger.debug("state_loaded", workflow_id=workflow_id)
+        return state
+
+    async def list_states(
+        self,
+        user_id: str | None = None,
+        status: WorkflowStatus | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[PortfolioState]:
+        """List workflow states with optional filters.
+
+        Args:
+            user_id: Filter by user ID.
+            status: Filter by status.
+            limit: Maximum results to return.
+            offset: Pagination offset.
+
+        Returns:
+            List of matching states.
+        """
+        pool = await self._get_pool()
+
+        # Build query with filters
+        conditions = []
+        params: list[Any] = []
+        param_idx = 1
+
+        if user_id:
+            conditions.append(f"user_id = ${param_idx}")
+            params.append(user_id)
+            param_idx += 1
+
+        if status:
+            conditions.append(f"status = ${param_idx}")
+            params.append(status.value)
+            param_idx += 1
+
+        where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+        select_sql = f"""
+        SELECT workflow_id, trace_id, user_id, portfolio, user_request, symbols,
+               research, analysis, recommendation, status, current_agent,
+               started_at, completed_at, error, messages, errors, context
+        FROM workflow_states
+        {where_clause}
+        ORDER BY started_at DESC
+        LIMIT ${param_idx} OFFSET ${param_idx + 1}
+        """
+        params.extend([limit, offset])
+
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(select_sql, *params)
+
+        states = []
+        for row in rows:
+            state: PortfolioState = {
+                "workflow_id": str(row["workflow_id"]),
+                "trace_id": str(row["trace_id"]),
+                "user_id": row["user_id"],
+                "portfolio": json.loads(row["portfolio"]),
+                "user_request": row["user_request"],
+                "symbols": list(row["symbols"]),
+                "research": json.loads(row["research"]) if row["research"] else None,
+                "analysis": json.loads(row["analysis"]) if row["analysis"] else None,
+                "recommendation": json.loads(row["recommendation"])
+                if row["recommendation"]
+                else None,
+                "status": row["status"],
+                "current_agent": row["current_agent"],
+                "started_at": row["started_at"].isoformat(),
+                "completed_at": row["completed_at"].isoformat() if row["completed_at"] else None,
+                "error": row["error"],
+                "messages": json.loads(row["messages"]),
+                "errors": list(row["errors"]),
+                "context": json.loads(row["context"]),
+            }
+            states.append(state)
+
+        return states
+
+    async def delete_state(self, workflow_id: str) -> bool:
+        """Delete workflow state.
+
+        Args:
+            workflow_id: Workflow identifier.
+
+        Returns:
+            True if deleted, False if not found.
+        """
+        pool = await self._get_pool()
+
+        delete_sql = "DELETE FROM workflow_states WHERE workflow_id = $1"
+
+        async with pool.acquire() as conn:
+            result = await conn.execute(delete_sql, uuid.UUID(workflow_id))
+
+        deleted: bool = result == "DELETE 1"
+        if deleted:
+            logger.debug("state_deleted", workflow_id=workflow_id)
+
+        return deleted
+
+    async def close(self) -> None:
+        """Close the connection pool."""
+        if self._pool:
+            await self._pool.close()
+            self._pool = None
+            logger.info("database_pool_closed")
+
+
+# ============================================================================
+# Convenience Functions for State Serialization
+# ============================================================================
+
+
+def state_to_json(state: PortfolioState) -> str:
+    """Serialize state to JSON string.
+
+    Args:
+        state: State to serialize.
+
+    Returns:
+        JSON string representation.
+    """
+    return json.dumps(state, default=str)
+
+
+def state_from_json(json_str: str) -> PortfolioState:
+    """Deserialize state from JSON string.
+
+    Args:
+        json_str: JSON string.
+
+    Returns:
+        Deserialized state.
+    """
+    data: PortfolioState = json.loads(json_str)
+    return data
+
+
+def get_state_summary(state: PortfolioState) -> dict[str, Any]:
+    """Get a summary of the state for logging/display.
+
+    Args:
+        state: State to summarize.
+
+    Returns:
+        Summary dict.
+    """
+    return {
+        "workflow_id": state.get("workflow_id"),
+        "status": state.get("status"),
+        "current_agent": state.get("current_agent"),
+        "symbol_count": len(state.get("symbols", [])),
+        "has_research": state.get("research") is not None,
+        "has_analysis": state.get("analysis") is not None,
+        "has_recommendation": state.get("recommendation") is not None,
+        "error_count": len(state.get("errors", [])),
+        "started_at": state.get("started_at"),
+        "completed_at": state.get("completed_at"),
+    }

--- a/tests/test_orchestration/test_state.py
+++ b/tests/test_orchestration/test_state.py
@@ -1,0 +1,1001 @@
+"""Tests for orchestration state management."""
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.orchestration.state import (
+    AgentName,
+    Portfolio,
+    Position,
+    StatePersistence,
+    StateValidationError,
+    WorkflowStatus,
+    create_initial_state,
+    get_state_summary,
+    mark_state_completed,
+    mark_state_failed,
+    state_from_json,
+    state_to_json,
+    update_state_for_agent,
+    update_state_with_result,
+    validate_state,
+    validate_state_or_raise,
+)
+
+# ============================================================================
+# Enum Tests
+# ============================================================================
+
+
+class TestWorkflowStatus:
+    """Tests for WorkflowStatus enum."""
+
+    def test_status_values(self) -> None:
+        """Test all status values exist."""
+        assert WorkflowStatus.PENDING.value == "pending"
+        assert WorkflowStatus.RUNNING.value == "running"
+        assert WorkflowStatus.COMPLETED.value == "completed"
+        assert WorkflowStatus.FAILED.value == "failed"
+        assert WorkflowStatus.CANCELLED.value == "cancelled"
+
+    def test_status_is_string(self) -> None:
+        """Test that status values are strings."""
+        for status in WorkflowStatus:
+            assert isinstance(status.value, str)
+            assert status.value == str(status.value)
+
+
+class TestAgentName:
+    """Tests for AgentName enum."""
+
+    def test_agent_names(self) -> None:
+        """Test all agent names exist."""
+        assert AgentName.RESEARCH.value == "research"
+        assert AgentName.ANALYSIS.value == "analysis"
+        assert AgentName.RECOMMENDATION.value == "recommendation"
+
+    def test_agent_count(self) -> None:
+        """Test there are exactly 3 agents."""
+        assert len(AgentName) == 3
+
+
+# ============================================================================
+# Position Tests
+# ============================================================================
+
+
+class TestPosition:
+    """Tests for Position model."""
+
+    def test_minimal_position(self) -> None:
+        """Test position with minimal fields."""
+        position = Position(symbol="AAPL", quantity=100)
+        assert position.symbol == "AAPL"
+        assert position.quantity == 100
+        assert position.cost_basis is None
+        assert position.current_price is None
+
+    def test_full_position(self) -> None:
+        """Test position with all fields."""
+        position = Position(
+            symbol="AAPL",
+            quantity=100,
+            cost_basis=150.0,
+            current_price=175.0,
+            market_value=17500.0,
+            weight=0.25,
+            sector="Technology",
+        )
+        assert position.symbol == "AAPL"
+        assert position.quantity == 100
+        assert position.cost_basis == 150.0
+        assert position.current_price == 175.0
+        assert position.market_value == 17500.0
+        assert position.weight == 0.25
+        assert position.sector == "Technology"
+
+    def test_position_from_dict(self) -> None:
+        """Test creating position from dict."""
+        position = Position(symbol="GOOGL", quantity=50, cost_basis=2800.0)
+        assert position.symbol == "GOOGL"
+        assert position.quantity == 50
+        assert position.cost_basis == 2800.0
+
+    def test_position_serialization(self) -> None:
+        """Test position can be serialized to dict."""
+        position = Position(symbol="MSFT", quantity=75, cost_basis=400.0)
+        data = position.model_dump()
+        assert data["symbol"] == "MSFT"
+        assert data["quantity"] == 75
+        assert data["cost_basis"] == 400.0
+
+
+# ============================================================================
+# Portfolio Tests
+# ============================================================================
+
+
+class TestPortfolio:
+    """Tests for Portfolio model."""
+
+    def test_empty_portfolio(self) -> None:
+        """Test empty portfolio."""
+        portfolio = Portfolio()
+        assert portfolio.positions == []
+        assert portfolio.total_value == 0.0
+        assert portfolio.cash == 0.0
+        assert portfolio.account_type == "taxable"
+
+    def test_portfolio_with_positions(self) -> None:
+        """Test portfolio with positions."""
+        positions = [
+            Position(symbol="AAPL", quantity=100, market_value=17500.0),
+            Position(symbol="GOOGL", quantity=50, market_value=14000.0),
+        ]
+        portfolio = Portfolio(
+            positions=positions,
+            total_value=31500.0,
+            cash=5000.0,
+            account_type="ira",
+        )
+        assert len(portfolio.positions) == 2
+        assert portfolio.total_value == 31500.0
+        assert portfolio.cash == 5000.0
+        assert portfolio.account_type == "ira"
+
+    def test_portfolio_symbols(self) -> None:
+        """Test symbols property."""
+        portfolio = Portfolio(
+            positions=[
+                Position(symbol="AAPL", quantity=100),
+                Position(symbol="GOOGL", quantity=50),
+                Position(symbol="MSFT", quantity=75),
+            ]
+        )
+        assert portfolio.symbols == ["AAPL", "GOOGL", "MSFT"]
+
+    def test_portfolio_weights(self) -> None:
+        """Test get_weights method."""
+        portfolio = Portfolio(
+            positions=[
+                Position(symbol="AAPL", quantity=100, market_value=5000.0),
+                Position(symbol="GOOGL", quantity=50, market_value=5000.0),
+            ],
+            total_value=10000.0,
+        )
+        weights = portfolio.get_weights()
+        assert weights["AAPL"] == 0.5
+        assert weights["GOOGL"] == 0.5
+
+    def test_portfolio_weights_zero_total(self) -> None:
+        """Test get_weights with zero total value."""
+        portfolio = Portfolio(
+            positions=[Position(symbol="AAPL", quantity=100)],
+            total_value=0.0,
+        )
+        weights = portfolio.get_weights()
+        assert weights == {}
+
+    def test_portfolio_from_dict_positions(self) -> None:
+        """Test portfolio parses positions from dicts."""
+        # Testing that Portfolio can parse dicts into Position objects
+        positions_data: list[dict[str, int | str]] = [
+            {"symbol": "AAPL", "quantity": 100},
+            {"symbol": "GOOGL", "quantity": 50},
+        ]
+        portfolio = Portfolio(positions=positions_data)  # type: ignore[arg-type]
+        assert len(portfolio.positions) == 2
+        assert portfolio.positions[0].symbol == "AAPL"
+        assert portfolio.positions[1].symbol == "GOOGL"
+
+    def test_portfolio_created_at(self) -> None:
+        """Test portfolio has created_at timestamp."""
+        portfolio = Portfolio()
+        assert portfolio.created_at is not None
+        assert isinstance(portfolio.created_at, datetime)
+
+    def test_portfolio_json_serialization(self) -> None:
+        """Test portfolio can be serialized to JSON."""
+        portfolio = Portfolio(
+            positions=[Position(symbol="AAPL", quantity=100)],
+            total_value=17500.0,
+        )
+        data = portfolio.model_dump(mode="json")
+        # Should be JSON-serializable (datetime converted to string)
+        json_str = json.dumps(data)
+        assert "AAPL" in json_str
+
+
+# ============================================================================
+# State Creation Tests
+# ============================================================================
+
+
+class TestCreateInitialState:
+    """Tests for create_initial_state function."""
+
+    def test_create_with_portfolio_model(self) -> None:
+        """Test creating state with Portfolio model."""
+        portfolio = Portfolio(
+            positions=[Position(symbol="AAPL", quantity=100)],
+            total_value=17500.0,
+        )
+        state = create_initial_state(
+            portfolio=portfolio,
+            user_request="Analyze my portfolio",
+        )
+
+        assert state["workflow_id"] is not None
+        assert state["trace_id"] is not None
+        assert state["user_id"] is None
+        assert state["portfolio"]["positions"][0]["symbol"] == "AAPL"
+        assert state["user_request"] == "Analyze my portfolio"
+        assert state["symbols"] == ["AAPL"]
+        assert state["status"] == "pending"
+        assert state["research"] is None
+        assert state["analysis"] is None
+        assert state["recommendation"] is None
+
+    def test_create_with_portfolio_dict(self) -> None:
+        """Test creating state with portfolio dict."""
+        portfolio_dict = {
+            "positions": [{"symbol": "GOOGL", "quantity": 50}],
+            "total_value": 14000.0,
+        }
+        state = create_initial_state(
+            portfolio=portfolio_dict,
+            user_request="Review positions",
+        )
+
+        assert state["symbols"] == ["GOOGL"]
+        assert state["portfolio"] == portfolio_dict
+
+    def test_create_with_user_id(self) -> None:
+        """Test creating state with user ID."""
+        state = create_initial_state(
+            portfolio=Portfolio(),
+            user_request="Test",
+            user_id="user-123",
+        )
+        assert state["user_id"] == "user-123"
+
+    def test_create_with_trace_id(self) -> None:
+        """Test creating state with custom trace ID."""
+        state = create_initial_state(
+            portfolio=Portfolio(),
+            user_request="Test",
+            trace_id="trace-abc-123",
+        )
+        assert state["trace_id"] == "trace-abc-123"
+
+    def test_state_has_timestamps(self) -> None:
+        """Test state has started_at timestamp."""
+        state = create_initial_state(
+            portfolio=Portfolio(),
+            user_request="Test",
+        )
+        assert state["started_at"] is not None
+        assert state["completed_at"] is None
+
+    def test_state_has_empty_collections(self) -> None:
+        """Test state initializes with empty collections."""
+        state = create_initial_state(
+            portfolio=Portfolio(),
+            user_request="Test",
+        )
+        assert state["messages"] == []
+        assert state["errors"] == []
+        assert state["context"] == {}
+
+
+# ============================================================================
+# State Update Tests
+# ============================================================================
+
+
+class TestUpdateStateForAgent:
+    """Tests for update_state_for_agent function."""
+
+    def test_update_for_research(self) -> None:
+        """Test updating state for research agent."""
+        state = create_initial_state(Portfolio(), "Test")
+        updated = update_state_for_agent(state, AgentName.RESEARCH)
+
+        assert updated["current_agent"] == "research"
+        assert updated["status"] == "running"
+
+    def test_update_for_analysis(self) -> None:
+        """Test updating state for analysis agent."""
+        state = create_initial_state(Portfolio(), "Test")
+        updated = update_state_for_agent(state, AgentName.ANALYSIS)
+
+        assert updated["current_agent"] == "analysis"
+        assert updated["status"] == "running"
+
+    def test_update_for_recommendation(self) -> None:
+        """Test updating state for recommendation agent."""
+        state = create_initial_state(Portfolio(), "Test")
+        updated = update_state_for_agent(state, AgentName.RECOMMENDATION)
+
+        assert updated["current_agent"] == "recommendation"
+        assert updated["status"] == "running"
+
+
+class TestUpdateStateWithResult:
+    """Tests for update_state_with_result function."""
+
+    def test_update_with_research_result(self) -> None:
+        """Test updating state with research result."""
+        state = create_initial_state(Portfolio(), "Test")
+        result = {
+            "market_data": {"AAPL": {"price": 175.0}},
+            "news": [],
+            "summary": "Research complete",
+            "symbols_researched": ["AAPL"],
+        }
+        updated = update_state_with_result(state, AgentName.RESEARCH, result)
+
+        assert updated["research"] is not None
+        assert updated["research"]["summary"] == "Research complete"
+
+    def test_update_with_analysis_result(self) -> None:
+        """Test updating state with analysis result."""
+        state = create_initial_state(Portfolio(), "Test")
+        result = {
+            "risk_metrics": {"volatility": 0.2},
+            "summary": "Analysis complete",
+        }
+        updated = update_state_with_result(state, AgentName.ANALYSIS, result)
+
+        assert updated["analysis"] is not None
+        assert updated["analysis"]["summary"] == "Analysis complete"
+
+    def test_update_with_recommendation_result(self) -> None:
+        """Test updating state with recommendation result."""
+        state = create_initial_state(Portfolio(), "Test")
+        result = {
+            "trades": [],
+            "summary": "Recommendations complete",
+            "total_trades": 0,
+        }
+        updated = update_state_with_result(state, AgentName.RECOMMENDATION, result)
+
+        assert updated["recommendation"] is not None
+        assert updated["recommendation"]["summary"] == "Recommendations complete"
+
+    def test_update_captures_errors(self) -> None:
+        """Test that errors from result are captured."""
+        state = create_initial_state(Portfolio(), "Test")
+        result = {
+            "summary": "Partial research",
+            "errors": ["Failed to fetch AAPL data", "API rate limited"],
+        }
+        updated = update_state_with_result(state, AgentName.RESEARCH, result)
+
+        assert "Failed to fetch AAPL data" in updated["errors"]
+        assert "API rate limited" in updated["errors"]
+
+
+class TestMarkStateCompleted:
+    """Tests for mark_state_completed function."""
+
+    def test_mark_completed(self) -> None:
+        """Test marking state as completed."""
+        state = create_initial_state(Portfolio(), "Test")
+        state = update_state_for_agent(state, AgentName.RESEARCH)
+        completed = mark_state_completed(state)
+
+        assert completed["status"] == "completed"
+        assert completed["completed_at"] is not None
+        assert completed["current_agent"] is None
+
+
+class TestMarkStateFailed:
+    """Tests for mark_state_failed function."""
+
+    def test_mark_failed(self) -> None:
+        """Test marking state as failed."""
+        state = create_initial_state(Portfolio(), "Test")
+        failed = mark_state_failed(state, "Connection timeout")
+
+        assert failed["status"] == "failed"
+        assert failed["completed_at"] is not None
+        assert failed["error"] == "Connection timeout"
+        assert "Connection timeout" in failed["errors"]
+
+
+# ============================================================================
+# State Validation Tests
+# ============================================================================
+
+
+class TestValidateState:
+    """Tests for validate_state function."""
+
+    def test_valid_state(self) -> None:
+        """Test validation passes for valid state."""
+        state = create_initial_state(Portfolio(), "Test request")
+        errors = validate_state(state)
+        assert errors == []
+
+    def test_missing_workflow_id(self) -> None:
+        """Test validation catches missing workflow_id."""
+        state = create_initial_state(Portfolio(), "Test")
+        state["workflow_id"] = ""
+        errors = validate_state(state)
+        assert any("workflow_id" in e for e in errors)
+
+    def test_missing_trace_id(self) -> None:
+        """Test validation catches missing trace_id."""
+        state = create_initial_state(Portfolio(), "Test")
+        state["trace_id"] = ""
+        errors = validate_state(state)
+        assert any("trace_id" in e for e in errors)
+
+    def test_missing_portfolio(self) -> None:
+        """Test validation catches missing portfolio."""
+        state = create_initial_state(Portfolio(), "Test")
+        state["portfolio"] = {}
+        errors = validate_state(state)
+        assert any("portfolio" in e for e in errors)
+
+    def test_missing_user_request(self) -> None:
+        """Test validation catches missing user_request."""
+        state = create_initial_state(Portfolio(), "Test")
+        state["user_request"] = ""
+        errors = validate_state(state)
+        assert any("user_request" in e for e in errors)
+
+    def test_invalid_status(self) -> None:
+        """Test validation catches invalid status."""
+        state = create_initial_state(Portfolio(), "Test")
+        state["status"] = "invalid_status"
+        errors = validate_state(state)
+        assert any("Invalid status" in e for e in errors)
+
+    def test_invalid_current_agent(self) -> None:
+        """Test validation catches invalid current_agent."""
+        state = create_initial_state(Portfolio(), "Test")
+        state["current_agent"] = "invalid_agent"
+        errors = validate_state(state)
+        assert any("Invalid current_agent" in e for e in errors)
+
+    def test_invalid_started_at_format(self) -> None:
+        """Test validation catches invalid started_at format."""
+        state = create_initial_state(Portfolio(), "Test")
+        state["started_at"] = "not-a-date"
+        errors = validate_state(state)
+        assert any("started_at" in e for e in errors)
+
+    def test_invalid_completed_at_format(self) -> None:
+        """Test validation catches invalid completed_at format."""
+        state = create_initial_state(Portfolio(), "Test")
+        state["completed_at"] = "not-a-date"
+        errors = validate_state(state)
+        assert any("completed_at" in e for e in errors)
+
+    def test_valid_iso_timestamps(self) -> None:
+        """Test validation accepts valid ISO timestamps."""
+        state = create_initial_state(Portfolio(), "Test")
+        state["started_at"] = "2024-01-15T10:30:00+00:00"
+        state["completed_at"] = "2024-01-15T10:35:00Z"
+        errors = validate_state(state)
+        assert errors == []
+
+
+class TestValidateStateOrRaise:
+    """Tests for validate_state_or_raise function."""
+
+    def test_valid_state_no_raise(self) -> None:
+        """Test no exception for valid state."""
+        state = create_initial_state(Portfolio(), "Test")
+        # Should not raise
+        validate_state_or_raise(state)
+
+    def test_invalid_state_raises(self) -> None:
+        """Test exception raised for invalid state."""
+        state = create_initial_state(Portfolio(), "Test")
+        state["workflow_id"] = ""
+        state["trace_id"] = ""
+
+        with pytest.raises(StateValidationError) as exc_info:
+            validate_state_or_raise(state)
+
+        assert "workflow_id" in str(exc_info.value)
+        assert "trace_id" in str(exc_info.value)
+
+
+# ============================================================================
+# State Serialization Tests
+# ============================================================================
+
+
+class TestStateSerialization:
+    """Tests for state serialization functions."""
+
+    def test_state_to_json(self) -> None:
+        """Test state can be serialized to JSON."""
+        state = create_initial_state(
+            Portfolio(positions=[Position(symbol="AAPL", quantity=100)]),
+            "Test",
+        )
+        json_str = state_to_json(state)
+        assert isinstance(json_str, str)
+        assert "AAPL" in json_str
+        assert "pending" in json_str
+
+    def test_state_from_json(self) -> None:
+        """Test state can be deserialized from JSON."""
+        state = create_initial_state(Portfolio(), "Test")
+        json_str = state_to_json(state)
+        restored = state_from_json(json_str)
+
+        assert restored["workflow_id"] == state["workflow_id"]
+        assert restored["user_request"] == state["user_request"]
+        assert restored["status"] == state["status"]
+
+    def test_roundtrip_serialization(self) -> None:
+        """Test state survives JSON roundtrip."""
+        portfolio = Portfolio(
+            positions=[
+                Position(symbol="AAPL", quantity=100, cost_basis=150.0),
+                Position(symbol="GOOGL", quantity=50, cost_basis=2800.0),
+            ],
+            total_value=31500.0,
+            cash=5000.0,
+        )
+        state = create_initial_state(portfolio, "Analyze portfolio", user_id="user-1")
+        state = update_state_for_agent(state, AgentName.RESEARCH)
+        state = update_state_with_result(
+            state,
+            AgentName.RESEARCH,
+            {"summary": "Done", "market_data": {}, "news": []},
+        )
+
+        json_str = state_to_json(state)
+        restored = state_from_json(json_str)
+
+        assert restored["workflow_id"] == state["workflow_id"]
+        assert restored["user_id"] == "user-1"
+        assert restored["research"] is not None
+        assert restored["research"]["summary"] == "Done"
+
+
+class TestGetStateSummary:
+    """Tests for get_state_summary function."""
+
+    def test_summary_fields(self) -> None:
+        """Test summary contains expected fields."""
+        state = create_initial_state(
+            Portfolio(positions=[Position(symbol="AAPL", quantity=100)]),
+            "Test",
+        )
+        summary = get_state_summary(state)
+
+        assert "workflow_id" in summary
+        assert "status" in summary
+        assert "current_agent" in summary
+        assert "symbol_count" in summary
+        assert "has_research" in summary
+        assert "has_analysis" in summary
+        assert "has_recommendation" in summary
+        assert "error_count" in summary
+        assert "started_at" in summary
+        assert "completed_at" in summary
+
+    def test_summary_values(self) -> None:
+        """Test summary has correct values."""
+        portfolio = Portfolio(
+            positions=[
+                Position(symbol="AAPL", quantity=100),
+                Position(symbol="GOOGL", quantity=50),
+            ]
+        )
+        state = create_initial_state(portfolio, "Test")
+        state = update_state_with_result(
+            state,
+            AgentName.RESEARCH,
+            {"summary": "Done"},
+        )
+        state["errors"] = ["Error 1", "Error 2"]
+
+        summary = get_state_summary(state)
+
+        assert summary["status"] == "pending"
+        assert summary["symbol_count"] == 2
+        assert summary["has_research"] is True
+        assert summary["has_analysis"] is False
+        assert summary["has_recommendation"] is False
+        assert summary["error_count"] == 2
+
+
+# ============================================================================
+# State Persistence Tests
+# ============================================================================
+
+
+class TestStatePersistence:
+    """Tests for StatePersistence class."""
+
+    def test_init_with_connection_string(self) -> None:
+        """Test initialization with explicit connection string."""
+        persistence = StatePersistence("postgresql://localhost:5432/test")
+        assert persistence.connection_string == "postgresql://localhost:5432/test"
+
+    def test_init_with_env_var(self) -> None:
+        """Test initialization with environment variable."""
+        with patch.dict("os.environ", {"DATABASE_URL": "postgresql://db:5432/mydb"}):
+            persistence = StatePersistence()
+            assert persistence.connection_string == "postgresql://db:5432/mydb"
+
+    def test_init_default(self) -> None:
+        """Test initialization with default connection string."""
+        with patch.dict("os.environ", {}, clear=True):
+            persistence = StatePersistence()
+            assert persistence.connection_string is not None
+            assert "portfolio_advisor" in persistence.connection_string
+
+    @pytest.mark.asyncio
+    async def test_initialize_schema(self) -> None:
+        """Test schema initialization."""
+        persistence = StatePersistence("postgresql://localhost:5432/test")
+
+        mock_conn = AsyncMock()
+        mock_pool = MagicMock()
+        mock_pool.acquire.return_value.__aenter__.return_value = mock_conn
+        mock_pool.acquire.return_value.__aexit__.return_value = None
+
+        with patch.object(
+            persistence, "_get_pool", new=AsyncMock(return_value=mock_pool)
+        ):
+            await persistence.initialize_schema()
+
+        mock_conn.execute.assert_called_once()
+        sql = mock_conn.execute.call_args[0][0]
+        assert "CREATE TABLE IF NOT EXISTS workflow_states" in sql
+
+    @pytest.mark.asyncio
+    async def test_save_state(self) -> None:
+        """Test saving state."""
+        persistence = StatePersistence("postgresql://localhost:5432/test")
+        state = create_initial_state(Portfolio(), "Test request")
+
+        mock_conn = AsyncMock()
+        mock_pool = MagicMock()
+        mock_pool.acquire.return_value.__aenter__.return_value = mock_conn
+        mock_pool.acquire.return_value.__aexit__.return_value = None
+
+        with patch.object(
+            persistence, "_get_pool", new=AsyncMock(return_value=mock_pool)
+        ):
+            await persistence.save_state(state)
+
+        mock_conn.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_save_state_validates(self) -> None:
+        """Test save_state validates state first."""
+        persistence = StatePersistence("postgresql://localhost:5432/test")
+        state = create_initial_state(Portfolio(), "Test")
+        state["workflow_id"] = ""  # Invalid
+
+        with pytest.raises(StateValidationError):
+            await persistence.save_state(state)
+
+    @pytest.mark.asyncio
+    async def test_load_state_found(self) -> None:
+        """Test loading existing state."""
+        persistence = StatePersistence("postgresql://localhost:5432/test")
+        workflow_id = "12345678-1234-1234-1234-123456789012"
+
+        mock_row = {
+            "workflow_id": workflow_id,
+            "trace_id": "trace-123",
+            "user_id": "user-1",
+            "portfolio": '{"positions": []}',
+            "user_request": "Test",
+            "symbols": ["AAPL"],
+            "research": None,
+            "analysis": None,
+            "recommendation": None,
+            "status": "pending",
+            "current_agent": None,
+            "started_at": datetime.now(UTC),
+            "completed_at": None,
+            "error": None,
+            "messages": "[]",
+            "errors": [],
+            "context": "{}",
+        }
+
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow.return_value = mock_row
+        mock_pool = MagicMock()
+        mock_pool.acquire.return_value.__aenter__.return_value = mock_conn
+        mock_pool.acquire.return_value.__aexit__.return_value = None
+
+        with patch.object(
+            persistence, "_get_pool", new=AsyncMock(return_value=mock_pool)
+        ):
+            state = await persistence.load_state(workflow_id)
+
+        assert state is not None
+        assert state["workflow_id"] == workflow_id
+        assert state["user_request"] == "Test"
+
+    @pytest.mark.asyncio
+    async def test_load_state_not_found(self) -> None:
+        """Test loading non-existent state."""
+        persistence = StatePersistence("postgresql://localhost:5432/test")
+        workflow_id = "00000000-0000-0000-0000-000000000000"  # Valid UUID format
+
+        mock_conn = AsyncMock()
+        mock_conn.fetchrow.return_value = None
+        mock_pool = MagicMock()
+        mock_pool.acquire.return_value.__aenter__.return_value = mock_conn
+        mock_pool.acquire.return_value.__aexit__.return_value = None
+
+        with patch.object(
+            persistence, "_get_pool", new=AsyncMock(return_value=mock_pool)
+        ):
+            state = await persistence.load_state(workflow_id)
+
+        assert state is None
+
+    @pytest.mark.asyncio
+    async def test_list_states(self) -> None:
+        """Test listing states."""
+        persistence = StatePersistence("postgresql://localhost:5432/test")
+
+        mock_rows: list[dict[str, Any]] = [
+            {
+                "workflow_id": "id-1",
+                "trace_id": "trace-1",
+                "user_id": "user-1",
+                "portfolio": '{"positions": []}',
+                "user_request": "Test 1",
+                "symbols": [],
+                "research": None,
+                "analysis": None,
+                "recommendation": None,
+                "status": "completed",
+                "current_agent": None,
+                "started_at": datetime.now(UTC),
+                "completed_at": datetime.now(UTC),
+                "error": None,
+                "messages": "[]",
+                "errors": [],
+                "context": "{}",
+            }
+        ]
+
+        mock_conn = AsyncMock()
+        mock_conn.fetch.return_value = mock_rows
+        mock_pool = MagicMock()
+        mock_pool.acquire.return_value.__aenter__.return_value = mock_conn
+        mock_pool.acquire.return_value.__aexit__.return_value = None
+
+        with patch.object(
+            persistence, "_get_pool", new=AsyncMock(return_value=mock_pool)
+        ):
+            states = await persistence.list_states(user_id="user-1", limit=10)
+
+        assert len(states) == 1
+        assert states[0]["user_request"] == "Test 1"
+
+    @pytest.mark.asyncio
+    async def test_list_states_with_status_filter(self) -> None:
+        """Test listing states with status filter."""
+        persistence = StatePersistence("postgresql://localhost:5432/test")
+
+        mock_conn = AsyncMock()
+        mock_conn.fetch.return_value = []
+        mock_pool = MagicMock()
+        mock_pool.acquire.return_value.__aenter__.return_value = mock_conn
+        mock_pool.acquire.return_value.__aexit__.return_value = None
+
+        with patch.object(
+            persistence, "_get_pool", new=AsyncMock(return_value=mock_pool)
+        ):
+            await persistence.list_states(status=WorkflowStatus.COMPLETED)
+
+        # Verify status was included in query
+        call_args = mock_conn.fetch.call_args
+        sql = call_args[0][0]
+        assert "status = $" in sql
+
+    @pytest.mark.asyncio
+    async def test_delete_state_success(self) -> None:
+        """Test deleting existing state."""
+        persistence = StatePersistence("postgresql://localhost:5432/test")
+        workflow_id = "11111111-1111-1111-1111-111111111111"
+
+        mock_conn = AsyncMock()
+        mock_conn.execute.return_value = "DELETE 1"
+        mock_pool = MagicMock()
+        mock_pool.acquire.return_value.__aenter__.return_value = mock_conn
+        mock_pool.acquire.return_value.__aexit__.return_value = None
+
+        with patch.object(
+            persistence, "_get_pool", new=AsyncMock(return_value=mock_pool)
+        ):
+            result = await persistence.delete_state(workflow_id)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_delete_state_not_found(self) -> None:
+        """Test deleting non-existent state."""
+        persistence = StatePersistence("postgresql://localhost:5432/test")
+        workflow_id = "00000000-0000-0000-0000-000000000000"
+
+        mock_conn = AsyncMock()
+        mock_conn.execute.return_value = "DELETE 0"
+        mock_pool = MagicMock()
+        mock_pool.acquire.return_value.__aenter__.return_value = mock_conn
+        mock_pool.acquire.return_value.__aexit__.return_value = None
+
+        with patch.object(
+            persistence, "_get_pool", new=AsyncMock(return_value=mock_pool)
+        ):
+            result = await persistence.delete_state(workflow_id)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_close(self) -> None:
+        """Test closing connection pool."""
+        persistence = StatePersistence("postgresql://localhost:5432/test")
+        mock_pool = AsyncMock()
+        persistence._pool = mock_pool
+
+        await persistence.close()
+
+        mock_pool.close.assert_called_once()
+        assert persistence._pool is None
+
+    @pytest.mark.asyncio
+    async def test_get_pool_caches_pool(self) -> None:
+        """Test connection pool is cached after creation."""
+        persistence = StatePersistence("postgresql://localhost:5432/test")
+
+        # Manually set a mock pool
+        mock_pool = MagicMock()
+        persistence._pool = mock_pool
+
+        # Should return the cached pool
+        pool = await persistence._get_pool()
+        assert pool is mock_pool
+
+    def test_pool_initially_none(self) -> None:
+        """Test connection pool starts as None."""
+        persistence = StatePersistence("postgresql://localhost:5432/test")
+        assert persistence._pool is None
+
+
+# ============================================================================
+# Integration Tests
+# ============================================================================
+
+
+class TestWorkflowStateFlow:
+    """Integration tests for workflow state transitions."""
+
+    def test_full_workflow_happy_path(self) -> None:
+        """Test complete workflow from start to finish."""
+        # Create initial state
+        portfolio = Portfolio(
+            positions=[
+                Position(symbol="AAPL", quantity=100, market_value=17500.0),
+                Position(symbol="GOOGL", quantity=50, market_value=14000.0),
+            ],
+            total_value=31500.0,
+            cash=5000.0,
+        )
+        state = create_initial_state(
+            portfolio=portfolio,
+            user_request="Analyze and recommend trades",
+            user_id="user-123",
+        )
+        assert state["status"] == "pending"
+
+        # Research phase
+        state = update_state_for_agent(state, AgentName.RESEARCH)
+        assert state["status"] == "running"
+        assert state["current_agent"] == "research"
+
+        state = update_state_with_result(
+            state,
+            AgentName.RESEARCH,
+            {
+                "market_data": {"AAPL": {"price": 175.0}, "GOOGL": {"price": 2800.0}},
+                "news": [{"headline": "Tech stocks rally"}],
+                "summary": "Research complete",
+            },
+        )
+        assert state["research"] is not None
+
+        # Analysis phase
+        state = update_state_for_agent(state, AgentName.ANALYSIS)
+        assert state["current_agent"] == "analysis"
+
+        state = update_state_with_result(
+            state,
+            AgentName.ANALYSIS,
+            {
+                "risk_metrics": {"volatility": 0.18, "sharpe_ratio": 1.2},
+                "summary": "Analysis complete",
+            },
+        )
+        assert state["analysis"] is not None
+
+        # Recommendation phase
+        state = update_state_for_agent(state, AgentName.RECOMMENDATION)
+        assert state["current_agent"] == "recommendation"
+
+        state = update_state_with_result(
+            state,
+            AgentName.RECOMMENDATION,
+            {
+                "trades": [{"symbol": "MSFT", "action": "buy", "quantity": 20}],
+                "summary": "Recommendations ready",
+                "total_trades": 1,
+            },
+        )
+        assert state["recommendation"] is not None
+
+        # Mark completed
+        state = mark_state_completed(state)
+        assert state["status"] == "completed"
+        assert state["completed_at"] is not None
+
+        # Validate final state
+        errors = validate_state(state)
+        assert errors == []
+
+    def test_workflow_failure_handling(self) -> None:
+        """Test workflow handles failure correctly."""
+        state = create_initial_state(Portfolio(), "Test")
+        state = update_state_for_agent(state, AgentName.RESEARCH)
+
+        # Simulate failure
+        state = mark_state_failed(state, "API connection failed")
+
+        assert state["status"] == "failed"
+        assert state["error"] == "API connection failed"
+        assert "API connection failed" in state["errors"]
+        assert state["completed_at"] is not None
+
+    def test_state_summary_progression(self) -> None:
+        """Test state summary updates through workflow."""
+        state = create_initial_state(
+            Portfolio(positions=[Position(symbol="AAPL", quantity=100)]),
+            "Test",
+        )
+
+        # Initial summary
+        summary = get_state_summary(state)
+        assert summary["status"] == "pending"
+        assert summary["has_research"] is False
+        assert summary["has_analysis"] is False
+        assert summary["has_recommendation"] is False
+
+        # After research
+        state = update_state_with_result(state, AgentName.RESEARCH, {"summary": "Done"})
+        summary = get_state_summary(state)
+        assert summary["has_research"] is True
+        assert summary["has_analysis"] is False
+
+        # After analysis
+        state = update_state_with_result(state, AgentName.ANALYSIS, {"summary": "Done"})
+        summary = get_state_summary(state)
+        assert summary["has_analysis"] is True
+
+        # After recommendation
+        state = update_state_with_result(state, AgentName.RECOMMENDATION, {"summary": "Done"})
+        summary = get_state_summary(state)
+        assert summary["has_recommendation"] is True


### PR DESCRIPTION
## Summary

- Implements GitHub issue #18: Define state schema and agent communication
- Creates `PortfolioState` TypedDict for LangGraph workflow state management
- Defines input schemas (`Position`, `Portfolio`) with Pydantic validation
- Adds agent output TypedDicts for type-safe state transitions
- Implements state factory functions, validation, and PostgreSQL persistence

## Key Components

### State Schema
- `PortfolioState` - Main workflow state with workflow_id, trace_id, agent outputs
- `WorkflowStatus` enum - pending, running, completed, failed, cancelled
- `AgentName` enum - research, analysis, recommendation

### Input Schemas
- `Position` - Stock position with symbol, quantity, cost_basis, market_value
- `Portfolio` - Collection of positions with total_value, cash, account_type

### State Management
- `create_initial_state()` - Factory for new workflow states
- `update_state_for_agent()` - Mark agent as running
- `update_state_with_result()` - Store agent output
- `mark_state_completed()` / `mark_state_failed()` - Terminal states
- `validate_state()` - Validate state structure and values

### Persistence
- `StatePersistence` class with PostgreSQL support via asyncpg
- Schema initialization, save/load/list/delete operations
- JSON serialization for complex nested types

## Test Plan

- [x] 66 unit tests covering all components
- [x] Enum value tests
- [x] Position and Portfolio model tests
- [x] State creation and update tests
- [x] Validation error detection tests
- [x] Serialization roundtrip tests
- [x] Persistence mocked tests
- [x] Integration workflow tests
- [x] All 495 project tests passing
- [x] Linting and type checking passing

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)