### PR TITLE
Add circuit breaker pattern for resilience

### DIFF
--- a/src/resilience/__init__.py
+++ b/src/resilience/__init__.py
@@ -1,0 +1,44 @@
+"""Resilience patterns for fault tolerance.
+
+This module contains:
+- Circuit breaker pattern for preventing cascade failures
+- Configuration for different service types (LLM, API, market data)
+"""
+
+from src.resilience.circuit_breaker import (
+    API_CIRCUIT_CONFIG,
+    LLM_CIRCUIT_CONFIG,
+    MARKET_DATA_CIRCUIT_CONFIG,
+    CircuitBreaker,
+    CircuitBreakerConfig,
+    CircuitOpenError,
+    CircuitState,
+    api_circuit_breaker,
+    circuit_breaker,
+    get_all_circuit_breakers,
+    get_circuit_breaker,
+    llm_circuit_breaker,
+    market_data_circuit_breaker,
+    reset_all_circuit_breakers,
+)
+
+__all__ = [
+    # Core classes
+    "CircuitBreaker",
+    "CircuitBreakerConfig",
+    "CircuitOpenError",
+    "CircuitState",
+    # Configurations
+    "API_CIRCUIT_CONFIG",
+    "LLM_CIRCUIT_CONFIG",
+    "MARKET_DATA_CIRCUIT_CONFIG",
+    # Decorators
+    "api_circuit_breaker",
+    "circuit_breaker",
+    "llm_circuit_breaker",
+    "market_data_circuit_breaker",
+    # Registry functions
+    "get_all_circuit_breakers",
+    "get_circuit_breaker",
+    "reset_all_circuit_breakers",
+]

--- a/src/resilience/circuit_breaker.py
+++ b/src/resilience/circuit_breaker.py
@@ -1,0 +1,451 @@
+"""Circuit breaker pattern implementation for resilience.
+
+This module implements the circuit breaker pattern to prevent cascade failures
+when external services (LLM, APIs) are experiencing issues.
+
+Circuit States:
+- CLOSED: Normal operation, requests pass through
+- OPEN: Service is failing, requests are rejected immediately
+- HALF_OPEN: Testing recovery, limited requests allowed
+"""
+
+import asyncio
+import functools
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, ParamSpec, TypeVar, cast
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class CircuitState(Enum):
+    """Circuit breaker states."""
+
+    CLOSED = "closed"  # Normal operation
+    OPEN = "open"  # Failing, reject requests
+    HALF_OPEN = "half_open"  # Testing recovery
+
+
+class CircuitOpenError(Exception):
+    """Raised when circuit is open and request is rejected."""
+
+    def __init__(self, name: str, recovery_time: float) -> None:
+        self.name = name
+        self.recovery_time = recovery_time
+        super().__init__(
+            f"Circuit '{name}' is open. Recovery in {recovery_time:.1f}s"
+        )
+
+
+@dataclass
+class CircuitBreakerConfig:
+    """Configuration for a circuit breaker.
+
+    Attributes:
+        failure_threshold: Number of failures before opening circuit.
+        recovery_timeout: Seconds to wait before attempting recovery.
+        half_open_max_calls: Max calls allowed in half-open state.
+        success_threshold: Successes needed in half-open to close circuit.
+        excluded_exceptions: Exceptions that don't count as failures.
+    """
+
+    failure_threshold: int = 5
+    recovery_timeout: float = 60.0
+    half_open_max_calls: int = 3
+    success_threshold: int = 2
+    excluded_exceptions: tuple[type[Exception], ...] = ()
+
+
+# Predefined configurations for common services
+LLM_CIRCUIT_CONFIG = CircuitBreakerConfig(
+    failure_threshold=5,
+    recovery_timeout=60.0,
+    half_open_max_calls=2,
+    success_threshold=2,
+)
+
+API_CIRCUIT_CONFIG = CircuitBreakerConfig(
+    failure_threshold=3,
+    recovery_timeout=30.0,
+    half_open_max_calls=3,
+    success_threshold=2,
+)
+
+MARKET_DATA_CIRCUIT_CONFIG = CircuitBreakerConfig(
+    failure_threshold=5,
+    recovery_timeout=45.0,
+    half_open_max_calls=2,
+    success_threshold=2,
+)
+
+
+@dataclass
+class CircuitBreaker:
+    """Circuit breaker implementation with async support.
+
+    Thread-safe circuit breaker that tracks failures and opens
+    the circuit when the failure threshold is reached.
+
+    Example:
+        breaker = CircuitBreaker("llm", LLM_CIRCUIT_CONFIG)
+
+        try:
+            async with breaker:
+                result = await call_llm(prompt)
+        except CircuitOpenError:
+            # Handle circuit open - use fallback
+            pass
+    """
+
+    name: str
+    config: CircuitBreakerConfig = field(default_factory=CircuitBreakerConfig)
+
+    # State tracking
+    _state: CircuitState = field(default=CircuitState.CLOSED, init=False)
+    _failure_count: int = field(default=0, init=False)
+    _success_count: int = field(default=0, init=False)
+    _last_failure_time: float | None = field(default=None, init=False)
+    _half_open_calls: int = field(default=0, init=False)
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+
+    @property
+    def state(self) -> CircuitState:
+        """Get current circuit state, checking for recovery."""
+        if self._state == CircuitState.OPEN and self._should_attempt_recovery():
+            return CircuitState.HALF_OPEN
+        return self._state
+
+    @property
+    def is_closed(self) -> bool:
+        """Check if circuit is closed (normal operation)."""
+        return self.state == CircuitState.CLOSED
+
+    @property
+    def is_open(self) -> bool:
+        """Check if circuit is open (rejecting requests)."""
+        return self._state == CircuitState.OPEN and not self._should_attempt_recovery()
+
+    @property
+    def failure_count(self) -> int:
+        """Get current failure count."""
+        return self._failure_count
+
+    @property
+    def time_until_recovery(self) -> float:
+        """Get seconds until recovery attempt is allowed."""
+        if self._last_failure_time is None:
+            return 0.0
+        elapsed = time.monotonic() - self._last_failure_time
+        remaining = self.config.recovery_timeout - elapsed
+        return max(0.0, remaining)
+
+    def _should_attempt_recovery(self) -> bool:
+        """Check if enough time has passed to attempt recovery."""
+        if self._last_failure_time is None:
+            return True
+        elapsed = time.monotonic() - self._last_failure_time
+        return elapsed >= self.config.recovery_timeout
+
+    async def _transition_to(self, new_state: CircuitState) -> None:
+        """Transition to a new state with logging."""
+        old_state = self._state
+        if old_state != new_state:
+            self._state = new_state
+            logger.info(
+                "circuit_state_changed",
+                circuit=self.name,
+                from_state=old_state.value,
+                to_state=new_state.value,
+                failure_count=self._failure_count,
+            )
+
+    async def record_success(self) -> None:
+        """Record a successful call."""
+        async with self._lock:
+            if self._state == CircuitState.HALF_OPEN:
+                self._success_count += 1
+                logger.debug(
+                    "circuit_half_open_success",
+                    circuit=self.name,
+                    success_count=self._success_count,
+                    threshold=self.config.success_threshold,
+                )
+                if self._success_count >= self.config.success_threshold:
+                    await self._close()
+            elif self._state == CircuitState.CLOSED:
+                # Reset failure count on success in closed state
+                if self._failure_count > 0:
+                    self._failure_count = 0
+                    logger.debug(
+                        "circuit_failure_count_reset",
+                        circuit=self.name,
+                    )
+
+    async def record_failure(self, exception: Exception) -> None:
+        """Record a failed call."""
+        # Check if exception should be excluded
+        if isinstance(exception, self.config.excluded_exceptions):
+            logger.debug(
+                "circuit_excluded_exception",
+                circuit=self.name,
+                exception_type=type(exception).__name__,
+            )
+            return
+
+        async with self._lock:
+            self._failure_count += 1
+            self._last_failure_time = time.monotonic()
+
+            logger.warning(
+                "circuit_failure_recorded",
+                circuit=self.name,
+                failure_count=self._failure_count,
+                threshold=self.config.failure_threshold,
+                exception_type=type(exception).__name__,
+                exception_msg=str(exception)[:200],
+            )
+
+            if self._state == CircuitState.HALF_OPEN:
+                # Any failure in half-open immediately opens circuit
+                await self._open()
+            elif self._failure_count >= self.config.failure_threshold:
+                await self._open()
+
+    async def _open(self) -> None:
+        """Open the circuit."""
+        await self._transition_to(CircuitState.OPEN)
+        self._half_open_calls = 0
+        self._success_count = 0
+        logger.warning(
+            "circuit_opened",
+            circuit=self.name,
+            failure_count=self._failure_count,
+            recovery_timeout=self.config.recovery_timeout,
+        )
+
+    async def _close(self) -> None:
+        """Close the circuit (normal operation)."""
+        await self._transition_to(CircuitState.CLOSED)
+        self._failure_count = 0
+        self._success_count = 0
+        self._half_open_calls = 0
+        self._last_failure_time = None
+        logger.info(
+            "circuit_closed",
+            circuit=self.name,
+        )
+
+    async def _enter_half_open(self) -> None:
+        """Enter half-open state for recovery testing."""
+        await self._transition_to(CircuitState.HALF_OPEN)
+        self._success_count = 0
+        self._half_open_calls = 0
+
+    async def allow_request(self) -> bool:
+        """Check if a request should be allowed through.
+
+        Returns:
+            True if request is allowed, False if rejected.
+
+        Raises:
+            CircuitOpenError: If circuit is open and rejecting requests.
+        """
+        async with self._lock:
+            current_state = self.state
+
+            if current_state == CircuitState.CLOSED:
+                return True
+
+            if current_state == CircuitState.OPEN:
+                raise CircuitOpenError(self.name, self.time_until_recovery)
+
+            # Half-open state
+            if self._state != CircuitState.HALF_OPEN:
+                await self._enter_half_open()
+
+            if self._half_open_calls >= self.config.half_open_max_calls:
+                raise CircuitOpenError(self.name, self.time_until_recovery)
+
+            self._half_open_calls += 1
+            logger.debug(
+                "circuit_half_open_request",
+                circuit=self.name,
+                call_number=self._half_open_calls,
+                max_calls=self.config.half_open_max_calls,
+            )
+            return True
+
+    async def __aenter__(self) -> "CircuitBreaker":
+        """Async context manager entry - check if request is allowed."""
+        await self.allow_request()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> bool:
+        """Async context manager exit - record success or failure."""
+        if exc_val is None:
+            await self.record_success()
+        elif isinstance(exc_val, Exception):
+            await self.record_failure(exc_val)
+        return False  # Don't suppress exceptions
+
+    def get_status(self) -> dict[str, Any]:
+        """Get current circuit breaker status for observability."""
+        return {
+            "name": self.name,
+            "state": self.state.value,
+            "failure_count": self._failure_count,
+            "failure_threshold": self.config.failure_threshold,
+            "time_until_recovery": self.time_until_recovery,
+            "recovery_timeout": self.config.recovery_timeout,
+        }
+
+
+# Global circuit breaker registry
+_circuit_breakers: dict[str, CircuitBreaker] = {}
+
+
+def get_circuit_breaker(
+    name: str,
+    config: CircuitBreakerConfig | None = None,
+) -> CircuitBreaker:
+    """Get or create a circuit breaker by name.
+
+    Args:
+        name: Unique name for the circuit breaker.
+        config: Configuration for the circuit breaker. Only used
+            when creating a new circuit breaker.
+
+    Returns:
+        Circuit breaker instance.
+    """
+    if name not in _circuit_breakers:
+        _circuit_breakers[name] = CircuitBreaker(
+            name=name,
+            config=config or CircuitBreakerConfig(),
+        )
+    return _circuit_breakers[name]
+
+
+def get_all_circuit_breakers() -> dict[str, CircuitBreaker]:
+    """Get all registered circuit breakers."""
+    return _circuit_breakers.copy()
+
+
+def reset_all_circuit_breakers() -> None:
+    """Reset all circuit breakers (for testing)."""
+    _circuit_breakers.clear()
+
+
+def circuit_breaker(
+    name: str,
+    config: CircuitBreakerConfig | None = None,
+    fallback: Callable[..., T] | None = None,
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Decorator to wrap a function with circuit breaker protection.
+
+    Args:
+        name: Name of the circuit breaker.
+        config: Configuration for the circuit breaker.
+        fallback: Optional fallback function when circuit is open.
+
+    Returns:
+        Decorated function.
+
+    Example:
+        @circuit_breaker("llm", LLM_CIRCUIT_CONFIG)
+        async def call_llm(prompt: str) -> str:
+            return await llm.invoke(prompt)
+    """
+
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
+        breaker = get_circuit_breaker(name, config)
+
+        @functools.wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                async with breaker:
+                    result = func(*args, **kwargs)
+                    if asyncio.iscoroutine(result):
+                        return await result
+                    return result
+            except CircuitOpenError:
+                if fallback is not None:
+                    logger.info(
+                        "circuit_using_fallback",
+                        circuit=name,
+                        function=func.__name__,
+                    )
+                    fallback_result = fallback(*args, **kwargs)
+                    if asyncio.iscoroutine(fallback_result):
+                        return await fallback_result
+                    return fallback_result
+                raise
+
+        @functools.wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            # For sync functions, we need to run in event loop
+            loop = asyncio.get_event_loop()
+            return loop.run_until_complete(async_wrapper(*args, **kwargs))
+
+        if asyncio.iscoroutinefunction(func):
+            return cast(Callable[P, T], async_wrapper)
+        return cast(Callable[P, T], sync_wrapper)
+
+    return decorator
+
+
+# Convenience decorators for common services
+def llm_circuit_breaker(
+    fallback: Callable[..., T] | None = None,
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Circuit breaker decorator for LLM calls.
+
+    Example:
+        @llm_circuit_breaker()
+        async def generate_response(prompt: str) -> str:
+            return await llm.invoke(prompt)
+    """
+    return circuit_breaker("llm", LLM_CIRCUIT_CONFIG, fallback)
+
+
+def api_circuit_breaker(
+    name: str,
+    fallback: Callable[..., T] | None = None,
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Circuit breaker decorator for external API calls.
+
+    Args:
+        name: Unique name for this API's circuit breaker.
+        fallback: Optional fallback function.
+
+    Example:
+        @api_circuit_breaker("market_data")
+        async def fetch_stock_price(symbol: str) -> float:
+            return await api.get_price(symbol)
+    """
+    return circuit_breaker(f"api_{name}", API_CIRCUIT_CONFIG, fallback)
+
+
+def market_data_circuit_breaker(
+    fallback: Callable[..., T] | None = None,
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Circuit breaker decorator for market data API calls.
+
+    Example:
+        @market_data_circuit_breaker()
+        async def fetch_market_data(symbol: str) -> dict:
+            return await yfinance.get_data(symbol)
+    """
+    return circuit_breaker("market_data", MARKET_DATA_CIRCUIT_CONFIG, fallback)

--- a/tests/test_resilience/__init__.py
+++ b/tests/test_resilience/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for resilience module."""

--- a/tests/test_resilience/test_circuit_breaker.py
+++ b/tests/test_resilience/test_circuit_breaker.py
@@ -1,0 +1,602 @@
+"""Tests for circuit breaker implementation."""
+
+import asyncio
+
+import pytest
+
+from src.resilience.circuit_breaker import (
+    API_CIRCUIT_CONFIG,
+    LLM_CIRCUIT_CONFIG,
+    MARKET_DATA_CIRCUIT_CONFIG,
+    CircuitBreaker,
+    CircuitBreakerConfig,
+    CircuitOpenError,
+    CircuitState,
+    api_circuit_breaker,
+    circuit_breaker,
+    get_all_circuit_breakers,
+    get_circuit_breaker,
+    llm_circuit_breaker,
+    market_data_circuit_breaker,
+    reset_all_circuit_breakers,
+)
+
+
+class TestCircuitState:
+    """Tests for CircuitState enum."""
+
+    def test_has_closed_state(self) -> None:
+        """Test CLOSED state exists."""
+        assert CircuitState.CLOSED.value == "closed"
+
+    def test_has_open_state(self) -> None:
+        """Test OPEN state exists."""
+        assert CircuitState.OPEN.value == "open"
+
+    def test_has_half_open_state(self) -> None:
+        """Test HALF_OPEN state exists."""
+        assert CircuitState.HALF_OPEN.value == "half_open"
+
+
+class TestCircuitBreakerConfig:
+    """Tests for CircuitBreakerConfig."""
+
+    def test_default_values(self) -> None:
+        """Test default configuration values."""
+        config = CircuitBreakerConfig()
+        assert config.failure_threshold == 5
+        assert config.recovery_timeout == 60.0
+        assert config.half_open_max_calls == 3
+        assert config.success_threshold == 2
+        assert config.excluded_exceptions == ()
+
+    def test_custom_values(self) -> None:
+        """Test custom configuration values."""
+        config = CircuitBreakerConfig(
+            failure_threshold=10,
+            recovery_timeout=120.0,
+            half_open_max_calls=5,
+            success_threshold=3,
+            excluded_exceptions=(ValueError,),
+        )
+        assert config.failure_threshold == 10
+        assert config.recovery_timeout == 120.0
+        assert config.half_open_max_calls == 5
+        assert config.success_threshold == 3
+        assert config.excluded_exceptions == (ValueError,)
+
+    def test_llm_config(self) -> None:
+        """Test predefined LLM circuit config."""
+        assert LLM_CIRCUIT_CONFIG.failure_threshold == 5
+        assert LLM_CIRCUIT_CONFIG.recovery_timeout == 60.0
+
+    def test_api_config(self) -> None:
+        """Test predefined API circuit config."""
+        assert API_CIRCUIT_CONFIG.failure_threshold == 3
+        assert API_CIRCUIT_CONFIG.recovery_timeout == 30.0
+
+    def test_market_data_config(self) -> None:
+        """Test predefined market data circuit config."""
+        assert MARKET_DATA_CIRCUIT_CONFIG.failure_threshold == 5
+        assert MARKET_DATA_CIRCUIT_CONFIG.recovery_timeout == 45.0
+
+
+class TestCircuitOpenError:
+    """Tests for CircuitOpenError exception."""
+
+    def test_error_message(self) -> None:
+        """Test error message formatting."""
+        error = CircuitOpenError("test_circuit", 30.5)
+        assert "test_circuit" in str(error)
+        assert "30.5" in str(error)
+        assert error.name == "test_circuit"
+        assert error.recovery_time == 30.5
+
+
+class TestCircuitBreaker:
+    """Tests for CircuitBreaker class."""
+
+    @pytest.fixture
+    def breaker(self) -> CircuitBreaker:
+        """Create a circuit breaker for testing."""
+        config = CircuitBreakerConfig(
+            failure_threshold=3,
+            recovery_timeout=1.0,  # Short for testing
+            half_open_max_calls=2,
+            success_threshold=2,
+        )
+        return CircuitBreaker("test", config)
+
+    @pytest.mark.asyncio
+    async def test_starts_closed(self, breaker: CircuitBreaker) -> None:
+        """Test circuit breaker starts in closed state."""
+        assert breaker.state == CircuitState.CLOSED
+        assert breaker.is_closed
+        assert not breaker.is_open
+
+    @pytest.mark.asyncio
+    async def test_allows_requests_when_closed(
+        self, breaker: CircuitBreaker
+    ) -> None:
+        """Test requests are allowed when closed."""
+        allowed = await breaker.allow_request()
+        assert allowed is True
+
+    @pytest.mark.asyncio
+    async def test_opens_after_threshold_failures(
+        self, breaker: CircuitBreaker
+    ) -> None:
+        """Test circuit opens after failure threshold is reached."""
+        # Record failures up to threshold
+        for _ in range(3):
+            await breaker.record_failure(Exception("test error"))
+
+        assert breaker.state == CircuitState.OPEN
+        assert breaker.is_open
+
+    @pytest.mark.asyncio
+    async def test_rejects_requests_when_open(
+        self, breaker: CircuitBreaker
+    ) -> None:
+        """Test requests are rejected when circuit is open."""
+        # Open the circuit
+        for _ in range(3):
+            await breaker.record_failure(Exception("test error"))
+
+        with pytest.raises(CircuitOpenError) as exc_info:
+            await breaker.allow_request()
+
+        assert exc_info.value.name == "test"
+
+    @pytest.mark.asyncio
+    async def test_success_resets_failure_count(
+        self, breaker: CircuitBreaker
+    ) -> None:
+        """Test success resets failure count when closed."""
+        await breaker.record_failure(Exception("test error"))
+        assert breaker.failure_count == 1
+
+        await breaker.record_success()
+        assert breaker.failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_transitions_to_half_open_after_recovery_timeout(
+        self, breaker: CircuitBreaker
+    ) -> None:
+        """Test circuit transitions to half-open after recovery timeout."""
+        # Open the circuit
+        for _ in range(3):
+            await breaker.record_failure(Exception("test error"))
+
+        assert breaker._state == CircuitState.OPEN
+
+        # Wait for recovery timeout
+        await asyncio.sleep(1.1)
+
+        # State property should now return HALF_OPEN
+        assert breaker.state == CircuitState.HALF_OPEN
+
+    @pytest.mark.asyncio
+    async def test_half_open_allows_limited_requests(
+        self, breaker: CircuitBreaker
+    ) -> None:
+        """Test half-open state allows limited requests."""
+        # Open the circuit
+        for _ in range(3):
+            await breaker.record_failure(Exception("test error"))
+
+        # Wait for recovery
+        await asyncio.sleep(1.1)
+
+        # Should allow up to half_open_max_calls requests
+        await breaker.allow_request()
+        await breaker.allow_request()
+
+        # Third request should be rejected
+        with pytest.raises(CircuitOpenError):
+            await breaker.allow_request()
+
+    @pytest.mark.asyncio
+    async def test_closes_after_successes_in_half_open(
+        self, breaker: CircuitBreaker
+    ) -> None:
+        """Test circuit closes after successful calls in half-open."""
+        # Open the circuit
+        for _ in range(3):
+            await breaker.record_failure(Exception("test error"))
+
+        # Wait for recovery
+        await asyncio.sleep(1.1)
+
+        # Transition to half-open and record successes
+        await breaker.allow_request()
+        await breaker.record_success()
+        await breaker.record_success()
+
+        assert breaker.state == CircuitState.CLOSED
+        assert breaker.is_closed
+
+    @pytest.mark.asyncio
+    async def test_reopens_on_failure_in_half_open(
+        self, breaker: CircuitBreaker
+    ) -> None:
+        """Test circuit reopens on failure in half-open state."""
+        # Open the circuit
+        for _ in range(3):
+            await breaker.record_failure(Exception("test error"))
+
+        # Wait for recovery
+        await asyncio.sleep(1.1)
+
+        # Enter half-open
+        await breaker.allow_request()
+
+        # Fail in half-open
+        await breaker.record_failure(Exception("test error"))
+
+        assert breaker._state == CircuitState.OPEN
+
+    @pytest.mark.asyncio
+    async def test_excluded_exceptions_not_counted(self) -> None:
+        """Test excluded exceptions don't count as failures."""
+        config = CircuitBreakerConfig(
+            failure_threshold=2,
+            excluded_exceptions=(ValueError,),
+        )
+        breaker = CircuitBreaker("test", config)
+
+        # ValueError should not count
+        await breaker.record_failure(ValueError("excluded"))
+        assert breaker.failure_count == 0
+
+        # Other exceptions should count
+        await breaker.record_failure(RuntimeError("included"))
+        assert breaker.failure_count == 1
+
+    @pytest.mark.asyncio
+    async def test_context_manager_success(
+        self, breaker: CircuitBreaker
+    ) -> None:
+        """Test context manager records success."""
+        async with breaker:
+            pass  # Successful operation
+
+        # Should have recorded success (failure count stays 0)
+        assert breaker.failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_context_manager_failure(
+        self, breaker: CircuitBreaker
+    ) -> None:
+        """Test context manager records failure."""
+        with pytest.raises(RuntimeError):
+            async with breaker:
+                raise RuntimeError("test error")
+
+        assert breaker.failure_count == 1
+
+    @pytest.mark.asyncio
+    async def test_get_status(self, breaker: CircuitBreaker) -> None:
+        """Test get_status returns expected fields."""
+        status = breaker.get_status()
+
+        assert status["name"] == "test"
+        assert status["state"] == "closed"
+        assert status["failure_count"] == 0
+        assert status["failure_threshold"] == 3
+        assert "time_until_recovery" in status
+        assert "recovery_timeout" in status
+
+    @pytest.mark.asyncio
+    async def test_time_until_recovery(
+        self, breaker: CircuitBreaker
+    ) -> None:
+        """Test time_until_recovery calculation."""
+        # Initially zero
+        assert breaker.time_until_recovery == 0.0
+
+        # After failure, should be close to recovery_timeout
+        await breaker.record_failure(Exception("test"))
+        assert breaker.time_until_recovery > 0.9
+        assert breaker.time_until_recovery <= 1.0
+
+
+class TestCircuitBreakerRegistry:
+    """Tests for circuit breaker registry functions."""
+
+    def setup_method(self) -> None:
+        """Reset registry before each test."""
+        reset_all_circuit_breakers()
+
+    def teardown_method(self) -> None:
+        """Reset registry after each test."""
+        reset_all_circuit_breakers()
+
+    def test_get_circuit_breaker_creates_new(self) -> None:
+        """Test get_circuit_breaker creates new circuit breaker."""
+        breaker = get_circuit_breaker("new_circuit")
+        assert breaker.name == "new_circuit"
+
+    def test_get_circuit_breaker_returns_existing(self) -> None:
+        """Test get_circuit_breaker returns existing circuit breaker."""
+        breaker1 = get_circuit_breaker("test")
+        breaker2 = get_circuit_breaker("test")
+        assert breaker1 is breaker2
+
+    def test_get_circuit_breaker_with_config(self) -> None:
+        """Test get_circuit_breaker with custom config."""
+        config = CircuitBreakerConfig(failure_threshold=10)
+        breaker = get_circuit_breaker("custom", config)
+        assert breaker.config.failure_threshold == 10
+
+    def test_get_all_circuit_breakers(self) -> None:
+        """Test get_all_circuit_breakers returns all registered."""
+        get_circuit_breaker("circuit1")
+        get_circuit_breaker("circuit2")
+
+        all_breakers = get_all_circuit_breakers()
+        assert "circuit1" in all_breakers
+        assert "circuit2" in all_breakers
+        assert len(all_breakers) == 2
+
+    def test_reset_all_circuit_breakers(self) -> None:
+        """Test reset_all_circuit_breakers clears registry."""
+        get_circuit_breaker("circuit1")
+        get_circuit_breaker("circuit2")
+
+        reset_all_circuit_breakers()
+
+        assert len(get_all_circuit_breakers()) == 0
+
+
+class TestCircuitBreakerDecorator:
+    """Tests for circuit_breaker decorator."""
+
+    def setup_method(self) -> None:
+        """Reset registry before each test."""
+        reset_all_circuit_breakers()
+
+    def teardown_method(self) -> None:
+        """Reset registry after each test."""
+        reset_all_circuit_breakers()
+
+    @pytest.mark.asyncio
+    async def test_decorator_wraps_async_function(self) -> None:
+        """Test decorator wraps async function."""
+        config = CircuitBreakerConfig(failure_threshold=2)
+
+        @circuit_breaker("test_async", config)
+        async def async_func() -> str:
+            return "success"
+
+        result = await async_func()
+        assert result == "success"
+
+    @pytest.mark.asyncio
+    async def test_decorator_records_success(self) -> None:
+        """Test decorator records successful calls."""
+        config = CircuitBreakerConfig(failure_threshold=2)
+
+        @circuit_breaker("test_success", config)
+        async def successful_func() -> str:
+            return "success"
+
+        await successful_func()
+
+        breaker = get_circuit_breaker("test_success")
+        assert breaker.failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_decorator_records_failure(self) -> None:
+        """Test decorator records failed calls."""
+        config = CircuitBreakerConfig(failure_threshold=2)
+
+        @circuit_breaker("test_failure", config)
+        async def failing_func() -> str:
+            raise RuntimeError("test error")
+
+        with pytest.raises(RuntimeError):
+            await failing_func()
+
+        breaker = get_circuit_breaker("test_failure")
+        assert breaker.failure_count == 1
+
+    @pytest.mark.asyncio
+    async def test_decorator_opens_circuit(self) -> None:
+        """Test decorator opens circuit after failures."""
+        config = CircuitBreakerConfig(failure_threshold=2)
+
+        @circuit_breaker("test_open", config)
+        async def failing_func() -> str:
+            raise RuntimeError("test error")
+
+        # Fail twice to open circuit
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                await failing_func()
+
+        # Next call should raise CircuitOpenError
+        with pytest.raises(CircuitOpenError):
+            await failing_func()
+
+    @pytest.mark.asyncio
+    async def test_decorator_with_fallback(self) -> None:
+        """Test decorator uses fallback when circuit is open."""
+        config = CircuitBreakerConfig(failure_threshold=2)
+
+        async def fallback_func() -> str:
+            return "fallback"
+
+        @circuit_breaker("test_fallback", config, fallback=fallback_func)
+        async def failing_func() -> str:
+            raise RuntimeError("test error")
+
+        # Fail twice to open circuit
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                await failing_func()
+
+        # Next call should use fallback
+        result = await failing_func()
+        assert result == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_decorator_with_sync_fallback(self) -> None:
+        """Test decorator works with sync fallback."""
+        config = CircuitBreakerConfig(failure_threshold=2)
+
+        def sync_fallback() -> str:
+            return "sync_fallback"
+
+        @circuit_breaker("test_sync_fallback", config, fallback=sync_fallback)
+        async def failing_func() -> str:
+            raise RuntimeError("test error")
+
+        # Fail twice to open circuit
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                await failing_func()
+
+        # Next call should use fallback
+        result = await failing_func()
+        assert result == "sync_fallback"
+
+
+class TestConvenienceDecorators:
+    """Tests for convenience decorators."""
+
+    def setup_method(self) -> None:
+        """Reset registry before each test."""
+        reset_all_circuit_breakers()
+
+    def teardown_method(self) -> None:
+        """Reset registry after each test."""
+        reset_all_circuit_breakers()
+
+    @pytest.mark.asyncio
+    async def test_llm_circuit_breaker(self) -> None:
+        """Test llm_circuit_breaker decorator."""
+
+        @llm_circuit_breaker()
+        async def call_llm() -> str:
+            return "llm response"
+
+        result = await call_llm()
+        assert result == "llm response"
+
+        # Check correct circuit was created
+        breaker = get_circuit_breaker("llm")
+        assert breaker.config.failure_threshold == 5
+        assert breaker.config.recovery_timeout == 60.0
+
+    @pytest.mark.asyncio
+    async def test_api_circuit_breaker(self) -> None:
+        """Test api_circuit_breaker decorator."""
+
+        @api_circuit_breaker("test_api")
+        async def call_api() -> str:
+            return "api response"
+
+        result = await call_api()
+        assert result == "api response"
+
+        # Check correct circuit was created
+        breaker = get_circuit_breaker("api_test_api")
+        assert breaker.config.failure_threshold == 3
+        assert breaker.config.recovery_timeout == 30.0
+
+    @pytest.mark.asyncio
+    async def test_market_data_circuit_breaker(self) -> None:
+        """Test market_data_circuit_breaker decorator."""
+
+        @market_data_circuit_breaker()
+        async def fetch_data() -> str:
+            return "market data"
+
+        result = await fetch_data()
+        assert result == "market data"
+
+        # Check correct circuit was created
+        breaker = get_circuit_breaker("market_data")
+        assert breaker.config.failure_threshold == 5
+        assert breaker.config.recovery_timeout == 45.0
+
+
+class TestCircuitBreakerIntegration:
+    """Integration tests for circuit breaker."""
+
+    def setup_method(self) -> None:
+        """Reset registry before each test."""
+        reset_all_circuit_breakers()
+
+    def teardown_method(self) -> None:
+        """Reset registry after each test."""
+        reset_all_circuit_breakers()
+
+    @pytest.mark.asyncio
+    async def test_full_cycle_with_recovery(self) -> None:
+        """Test full circuit breaker cycle: closed -> open -> half-open -> closed."""
+        config = CircuitBreakerConfig(
+            failure_threshold=2,
+            recovery_timeout=0.5,
+            half_open_max_calls=2,
+            success_threshold=2,
+        )
+        breaker = CircuitBreaker("integration_test", config)
+
+        # Start closed
+        assert breaker.state == CircuitState.CLOSED
+
+        # Fail to open
+        for _ in range(2):
+            await breaker.record_failure(Exception("fail"))
+        assert breaker._state == CircuitState.OPEN
+
+        # Wait for recovery
+        await asyncio.sleep(0.6)
+        assert breaker.state == CircuitState.HALF_OPEN
+
+        # Succeed to close
+        await breaker.allow_request()
+        await breaker.record_success()
+        await breaker.record_success()
+        assert breaker.state == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_multiple_circuits_independent(self) -> None:
+        """Test multiple circuits operate independently."""
+        breaker1 = get_circuit_breaker(
+            "circuit1",
+            CircuitBreakerConfig(failure_threshold=2),
+        )
+        breaker2 = get_circuit_breaker(
+            "circuit2",
+            CircuitBreakerConfig(failure_threshold=2),
+        )
+
+        # Open circuit1
+        for _ in range(2):
+            await breaker1.record_failure(Exception("fail"))
+
+        # Circuit1 is open, circuit2 is still closed
+        assert breaker1._state == CircuitState.OPEN
+        assert breaker2.state == CircuitState.CLOSED
+
+        # Can still use circuit2
+        allowed = await breaker2.allow_request()
+        assert allowed is True
+
+    @pytest.mark.asyncio
+    async def test_concurrent_access(self) -> None:
+        """Test circuit breaker handles concurrent access."""
+        config = CircuitBreakerConfig(failure_threshold=5)
+        breaker = CircuitBreaker("concurrent_test", config)
+
+        async def record_failure() -> None:
+            await breaker.record_failure(Exception("fail"))
+
+        # Concurrent failures
+        await asyncio.gather(*[record_failure() for _ in range(5)])
+
+        assert breaker._state == CircuitState.OPEN
+        assert breaker.failure_count >= 5


### PR DESCRIPTION
## Summary

- Implement circuit breaker pattern to prevent cascade failures
- Support for LLM, external API, and market data services
- Async-first design with decorator and context manager support
- 40 comprehensive tests with full coverage

## Circuit Breaker States

```
CLOSED (normal) ──failures exceed threshold──► OPEN (rejecting)
     ▲                                              │
     │                                    recovery timeout
     │                                              ▼
     └─────successes in half-open──────── HALF_OPEN (testing)
```

## Key Features

- **CircuitBreakerConfig**: Customizable thresholds, timeouts, excluded exceptions
- **Predefined configs**: LLM_CIRCUIT_CONFIG, API_CIRCUIT_CONFIG, MARKET_DATA_CIRCUIT_CONFIG
- **Decorators**: `@circuit_breaker()`, `@llm_circuit_breaker()`, `@api_circuit_breaker()`, `@market_data_circuit_breaker()`
- **Fallback support**: Optional fallback functions when circuit is open
- **Observability**: All state changes logged via structlog
- **Global registry**: Track and manage all circuit breakers

## Usage Example

```python
from src.resilience import llm_circuit_breaker, CircuitOpenError

@llm_circuit_breaker()
async def call_llm(prompt: str) -> str:
    return await anthropic.messages.create(...)

# Or with fallback
@llm_circuit_breaker(fallback=lambda p: "Service unavailable")
async def call_llm_with_fallback(prompt: str) -> str:
    return await anthropic.messages.create(...)
```

## Test plan

- [x] Test CircuitState enum values
- [x] Test CircuitBreakerConfig defaults and custom values
- [x] Test CircuitBreaker state transitions (closed→open→half-open→closed)
- [x] Test request rejection when circuit is open
- [x] Test recovery after timeout
- [x] Test excluded exceptions don't count as failures
- [x] Test decorator wrapping async functions
- [x] Test fallback functions (async and sync)
- [x] Test convenience decorators (llm, api, market_data)
- [x] Test global registry functions
- [x] Test concurrent access
- [x] All 40 tests passing
- [x] Mypy type checking passes

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)