### PR TITLE
feat: Add graceful degradation for service continuity (#34)

### DIFF
--- a/src/resilience/__init__.py
+++ b/src/resilience/__init__.py
@@ -3,6 +3,7 @@
 This module contains:
 - Circuit breaker pattern for preventing cascade failures
 - Rate limiting for API protection and cost management
+- Graceful degradation for service continuity
 - Configuration for different service types (LLM, API, market data)
 """
 
@@ -22,15 +23,30 @@ from src.resilience.circuit_breaker import (
     market_data_circuit_breaker,
     reset_all_circuit_breakers,
 )
+from src.resilience.degradation import (
+    ComponentHealth,
+    ComponentStatus,
+    ComponentType,
+    DegradationLevel,
+    DegradationManager,
+    DegradationMetrics,
+    DegradationStrategy,
+    DegradedResponse,
+    FallbackChain,
+    get_degradation_manager,
+    reset_degradation_manager,
+    set_degradation_manager,
+    with_fallback,
+)
 from src.resilience.rate_limiter import (
     DEFAULT_RATE_LIMIT_CONFIG,
     CostLimitExceeded,
     CostTracker,
     LimitType,
     RateLimitConfig,
+    RateLimiter,
     RateLimitExceeded,
     RateLimitHeaders,
-    RateLimiter,
     TokenBucket,
     get_rate_limiter,
     reset_rate_limiter,
@@ -55,6 +71,22 @@ __all__ = [
     "get_all_circuit_breakers",
     "get_circuit_breaker",
     "reset_all_circuit_breakers",
+    # Degradation classes
+    "ComponentHealth",
+    "ComponentStatus",
+    "ComponentType",
+    "DegradationLevel",
+    "DegradationManager",
+    "DegradationMetrics",
+    "DegradationStrategy",
+    "DegradedResponse",
+    "FallbackChain",
+    # Degradation utilities
+    "with_fallback",
+    # Degradation global instance
+    "get_degradation_manager",
+    "reset_degradation_manager",
+    "set_degradation_manager",
     # Rate limiter classes
     "CostLimitExceeded",
     "CostTracker",

--- a/src/resilience/degradation.py
+++ b/src/resilience/degradation.py
@@ -1,0 +1,662 @@
+"""Graceful degradation for service continuity during partial outages.
+
+This module provides:
+- Degradation levels for different failure scenarios
+- Component status tracking
+- Degraded response wrappers
+- Degradation monitoring and alerting
+
+Features:
+- Automatic degradation based on component health
+- User-facing warnings about degraded state
+- Fallback strategies per component
+- Degradation metrics for observability
+"""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any, Generic, ParamSpec, TypeVar, cast
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+class DegradationLevel(Enum):
+    """Degradation levels from best to worst service quality.
+
+    Each level represents a different quality of service based on
+    which components are available.
+    """
+
+    FULL = "full"  # All features working
+    CACHED_DATA = "cached_data"  # Using cached market data
+    MOCK_DATA = "mock_data"  # Using mock data
+    BASIC_ANALYSIS = "basic_analysis"  # Only basic metrics
+    RECOMMENDATIONS_ONLY = "recommendations_only"  # Skip analysis details
+    UNAVAILABLE = "unavailable"  # Service unavailable
+
+    def is_degraded(self) -> bool:
+        """Check if this level represents degraded service."""
+        return self != DegradationLevel.FULL
+
+    def severity(self) -> int:
+        """Get severity level (higher = more degraded)."""
+        severity_map = {
+            DegradationLevel.FULL: 0,
+            DegradationLevel.CACHED_DATA: 1,
+            DegradationLevel.MOCK_DATA: 2,
+            DegradationLevel.BASIC_ANALYSIS: 3,
+            DegradationLevel.RECOMMENDATIONS_ONLY: 4,
+            DegradationLevel.UNAVAILABLE: 5,
+        }
+        return severity_map[self]
+
+
+class ComponentType(Enum):
+    """Types of components that can fail."""
+
+    MARKET_DATA_API = "market_data_api"
+    NEWS_API = "news_api"
+    LLM = "llm"
+    REDIS = "redis"
+    POSTGRES = "postgres"
+
+
+class ComponentHealth(Enum):
+    """Health status of a component."""
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNHEALTHY = "unhealthy"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class ComponentStatus:
+    """Status of a single component.
+
+    Attributes:
+        component: Type of component.
+        health: Current health status.
+        last_check: Timestamp of last health check.
+        last_healthy: Timestamp when last healthy.
+        failure_count: Consecutive failure count.
+        error_message: Last error message if unhealthy.
+    """
+
+    component: ComponentType
+    health: ComponentHealth = ComponentHealth.UNKNOWN
+    last_check: datetime = field(default_factory=lambda: datetime.now(UTC))
+    last_healthy: datetime | None = None
+    failure_count: int = 0
+    error_message: str | None = None
+
+    def mark_healthy(self) -> None:
+        """Mark component as healthy."""
+        self.health = ComponentHealth.HEALTHY
+        self.last_check = datetime.now(UTC)
+        self.last_healthy = self.last_check
+        self.failure_count = 0
+        self.error_message = None
+
+    def mark_unhealthy(self, error: str | None = None) -> None:
+        """Mark component as unhealthy."""
+        self.health = ComponentHealth.UNHEALTHY
+        self.last_check = datetime.now(UTC)
+        self.failure_count += 1
+        self.error_message = error
+
+    def mark_degraded(self, error: str | None = None) -> None:
+        """Mark component as degraded (partially working)."""
+        self.health = ComponentHealth.DEGRADED
+        self.last_check = datetime.now(UTC)
+        self.error_message = error
+
+    def is_available(self) -> bool:
+        """Check if component is available (healthy or degraded)."""
+        return self.health in (ComponentHealth.HEALTHY, ComponentHealth.DEGRADED)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "component": self.component.value,
+            "health": self.health.value,
+            "last_check": self.last_check.isoformat(),
+            "last_healthy": self.last_healthy.isoformat() if self.last_healthy else None,
+            "failure_count": self.failure_count,
+            "error_message": self.error_message,
+        }
+
+
+@dataclass
+class DegradedResponse(Generic[T]):
+    """Response wrapper that includes degradation information.
+
+    Attributes:
+        result: The actual response data.
+        degradation_level: Current degradation level.
+        warnings: List of warnings about degraded state.
+        timestamp: When the response was generated.
+        cache_age_seconds: Age of cached data if using cache.
+    """
+
+    result: T
+    degradation_level: DegradationLevel = DegradationLevel.FULL
+    warnings: list[str] = field(default_factory=list)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+    cache_age_seconds: float | None = None
+
+    def add_warning(self, warning: str) -> None:
+        """Add a warning message."""
+        self.warnings.append(warning)
+
+    def is_degraded(self) -> bool:
+        """Check if response is degraded."""
+        return self.degradation_level.is_degraded()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "result": self.result,
+            "degradation_level": self.degradation_level.value,
+            "warnings": self.warnings,
+            "timestamp": self.timestamp.isoformat(),
+            "cache_age_seconds": self.cache_age_seconds,
+        }
+
+
+@dataclass
+class DegradationMetrics:
+    """Metrics for degradation monitoring.
+
+    Attributes:
+        degradation_events: Count of degradation events by level.
+        component_failures: Count of failures by component.
+        total_degraded_requests: Total requests served in degraded state.
+        total_full_requests: Total requests served at full capacity.
+    """
+
+    degradation_events: dict[DegradationLevel, int] = field(
+        default_factory=lambda: dict.fromkeys(DegradationLevel, 0)
+    )
+    component_failures: dict[ComponentType, int] = field(
+        default_factory=lambda: dict.fromkeys(ComponentType, 0)
+    )
+    total_degraded_requests: int = 0
+    total_full_requests: int = 0
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+
+    async def record_degradation(self, level: DegradationLevel) -> None:
+        """Record a degradation event."""
+        async with self._lock:
+            self.degradation_events[level] += 1
+            if level.is_degraded():
+                self.total_degraded_requests += 1
+            else:
+                self.total_full_requests += 1
+
+    async def record_component_failure(self, component: ComponentType) -> None:
+        """Record a component failure."""
+        async with self._lock:
+            self.component_failures[component] += 1
+
+    @property
+    def degraded_ratio(self) -> float:
+        """Ratio of degraded to total requests."""
+        total = self.total_degraded_requests + self.total_full_requests
+        if total == 0:
+            return 0.0
+        return self.total_degraded_requests / total
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "degradation_events": {k.value: v for k, v in self.degradation_events.items()},
+            "component_failures": {k.value: v for k, v in self.component_failures.items()},
+            "total_degraded_requests": self.total_degraded_requests,
+            "total_full_requests": self.total_full_requests,
+            "degraded_ratio": round(self.degraded_ratio, 4),
+        }
+
+    def reset(self) -> None:
+        """Reset all metrics."""
+        self.degradation_events = dict.fromkeys(DegradationLevel, 0)
+        self.component_failures = dict.fromkeys(ComponentType, 0)
+        self.total_degraded_requests = 0
+        self.total_full_requests = 0
+
+
+class DegradationStrategy:
+    """Strategy for handling component failures.
+
+    Maps component failures to degradation levels and fallback behaviors.
+    """
+
+    # Default degradation mapping for component failures
+    DEFAULT_DEGRADATION_MAP: dict[ComponentType, DegradationLevel] = {
+        ComponentType.MARKET_DATA_API: DegradationLevel.CACHED_DATA,
+        ComponentType.NEWS_API: DegradationLevel.CACHED_DATA,
+        ComponentType.LLM: DegradationLevel.BASIC_ANALYSIS,
+        ComponentType.REDIS: DegradationLevel.FULL,  # Can bypass cache
+        ComponentType.POSTGRES: DegradationLevel.RECOMMENDATIONS_ONLY,
+    }
+
+    # Warning messages for each degradation scenario
+    DEFAULT_WARNINGS: dict[ComponentType, str] = {
+        ComponentType.MARKET_DATA_API: "Market data may be outdated",
+        ComponentType.NEWS_API: "News analysis unavailable",
+        ComponentType.LLM: "Using simplified analysis",
+        ComponentType.REDIS: "Responses may be slower (cache bypassed)",
+        ComponentType.POSTGRES: "Read-only mode, some features limited",
+    }
+
+    def __init__(
+        self,
+        degradation_map: dict[ComponentType, DegradationLevel] | None = None,
+        warnings: dict[ComponentType, str] | None = None,
+    ) -> None:
+        """Initialize strategy.
+
+        Args:
+            degradation_map: Custom component to degradation level mapping.
+            warnings: Custom warning messages per component.
+        """
+        self.degradation_map = degradation_map or self.DEFAULT_DEGRADATION_MAP.copy()
+        self.warnings = warnings or self.DEFAULT_WARNINGS.copy()
+
+    def get_degradation_level(
+        self, failed_components: set[ComponentType]
+    ) -> DegradationLevel:
+        """Determine degradation level based on failed components.
+
+        Returns the worst (highest severity) degradation level.
+
+        Args:
+            failed_components: Set of failed component types.
+
+        Returns:
+            Worst degradation level required.
+        """
+        if not failed_components:
+            return DegradationLevel.FULL
+
+        levels = [
+            self.degradation_map.get(comp, DegradationLevel.UNAVAILABLE)
+            for comp in failed_components
+        ]
+        return max(levels, key=lambda x: x.severity())
+
+    def get_warnings(self, failed_components: set[ComponentType]) -> list[str]:
+        """Get warning messages for failed components.
+
+        Args:
+            failed_components: Set of failed component types.
+
+        Returns:
+            List of warning messages.
+        """
+        return [
+            self.warnings[comp]
+            for comp in failed_components
+            if comp in self.warnings
+        ]
+
+
+class DegradationManager:
+    """Manager for graceful degradation.
+
+    Coordinates component health tracking, degradation level determination,
+    and response wrapping.
+
+    Example:
+        manager = DegradationManager()
+
+        # Report component health
+        await manager.mark_healthy(ComponentType.MARKET_DATA_API)
+        await manager.mark_unhealthy(ComponentType.NEWS_API, "API timeout")
+
+        # Get current degradation level
+        level = manager.get_degradation_level()
+
+        # Wrap a response with degradation info
+        response = manager.wrap_response(data, cache_age=300)
+    """
+
+    def __init__(
+        self,
+        strategy: DegradationStrategy | None = None,
+        alert_callback: Callable[[DegradationLevel, list[str]], Awaitable[None]] | None = None,
+    ) -> None:
+        """Initialize degradation manager.
+
+        Args:
+            strategy: Degradation strategy to use.
+            alert_callback: Async callback for alerts on degradation changes.
+        """
+        self.strategy = strategy or DegradationStrategy()
+        self.alert_callback = alert_callback
+        self.metrics = DegradationMetrics()
+        self._components: dict[ComponentType, ComponentStatus] = {}
+        for comp in ComponentType:
+            status = ComponentStatus(component=comp)
+            status.health = ComponentHealth.HEALTHY  # Start all components as healthy
+            self._components[comp] = status
+        self._current_level = DegradationLevel.FULL
+        self._lock = asyncio.Lock()
+
+    async def mark_healthy(self, component: ComponentType) -> None:
+        """Mark a component as healthy.
+
+        Args:
+            component: Component type to mark healthy.
+        """
+        async with self._lock:
+            self._components[component].mark_healthy()
+            await self._update_degradation_level()
+
+        logger.debug("component_healthy", component=component.value)
+
+    async def mark_unhealthy(
+        self, component: ComponentType, error: str | None = None
+    ) -> None:
+        """Mark a component as unhealthy.
+
+        Args:
+            component: Component type to mark unhealthy.
+            error: Error message describing the failure.
+        """
+        async with self._lock:
+            self._components[component].mark_unhealthy(error)
+            await self.metrics.record_component_failure(component)
+            await self._update_degradation_level()
+
+        logger.warning(
+            "component_unhealthy",
+            component=component.value,
+            error=error,
+            failure_count=self._components[component].failure_count,
+        )
+
+    async def mark_degraded(
+        self, component: ComponentType, error: str | None = None
+    ) -> None:
+        """Mark a component as degraded (partially working).
+
+        Args:
+            component: Component type to mark degraded.
+            error: Error message describing the issue.
+        """
+        async with self._lock:
+            self._components[component].mark_degraded(error)
+            await self._update_degradation_level()
+
+        logger.info("component_degraded", component=component.value, error=error)
+
+    async def _update_degradation_level(self) -> None:
+        """Update the current degradation level based on component health."""
+        failed = {
+            comp
+            for comp, status in self._components.items()
+            if not status.is_available()
+        }
+
+        new_level = self.strategy.get_degradation_level(failed)
+
+        if new_level != self._current_level:
+            old_level = self._current_level
+            self._current_level = new_level
+
+            await self.metrics.record_degradation(new_level)
+
+            logger.info(
+                "degradation_level_changed",
+                old_level=old_level.value,
+                new_level=new_level.value,
+                failed_components=[c.value for c in failed],
+            )
+
+            # Trigger alert callback if degradation worsened
+            if new_level.severity() > old_level.severity() and self.alert_callback:
+                warnings = self.strategy.get_warnings(failed)
+                await self.alert_callback(new_level, warnings)
+
+    def get_degradation_level(self) -> DegradationLevel:
+        """Get current degradation level.
+
+        Returns:
+            Current degradation level.
+        """
+        return self._current_level
+
+    def get_component_status(self, component: ComponentType) -> ComponentStatus:
+        """Get status of a specific component.
+
+        Args:
+            component: Component type.
+
+        Returns:
+            Component status.
+        """
+        return self._components[component]
+
+    def get_all_component_statuses(self) -> dict[ComponentType, ComponentStatus]:
+        """Get status of all components.
+
+        Returns:
+            Dictionary of component statuses.
+        """
+        return self._components.copy()
+
+    def get_failed_components(self) -> set[ComponentType]:
+        """Get set of currently failed components.
+
+        Returns:
+            Set of failed component types.
+        """
+        return {
+            comp
+            for comp, status in self._components.items()
+            if not status.is_available()
+        }
+
+    def wrap_response(
+        self,
+        result: T,
+        cache_age: float | None = None,
+    ) -> DegradedResponse[T]:
+        """Wrap a result with degradation information.
+
+        Args:
+            result: The result to wrap.
+            cache_age: Age of cached data in seconds.
+
+        Returns:
+            DegradedResponse with degradation info.
+        """
+        failed = self.get_failed_components()
+        warnings = self.strategy.get_warnings(failed)
+
+        if cache_age is not None and cache_age > 60:
+            warnings.append(f"Data from cache ({int(cache_age)} seconds old)")
+
+        return DegradedResponse(
+            result=result,
+            degradation_level=self._current_level,
+            warnings=warnings,
+            cache_age_seconds=cache_age,
+        )
+
+    def get_metrics(self) -> dict[str, Any]:
+        """Get degradation metrics.
+
+        Returns:
+            Dictionary of metrics.
+        """
+        return self.metrics.to_dict()
+
+    def reset_metrics(self) -> None:
+        """Reset degradation metrics."""
+        self.metrics.reset()
+
+    def get_health_summary(self) -> dict[str, Any]:
+        """Get a summary of system health.
+
+        Returns:
+            Dictionary with health summary.
+        """
+        return {
+            "degradation_level": self._current_level.value,
+            "is_degraded": self._current_level.is_degraded(),
+            "components": {
+                comp.value: status.to_dict()
+                for comp, status in self._components.items()
+            },
+            "failed_components": [c.value for c in self.get_failed_components()],
+            "metrics": self.get_metrics(),
+        }
+
+
+def with_fallback(
+    fallback_fn: Callable[P, T | Awaitable[T]],
+    on_error: Callable[[Exception], None] | None = None,
+) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
+    """Decorator to provide fallback on failure.
+
+    Args:
+        fallback_fn: Function to call if primary fails.
+        on_error: Optional callback when error occurs.
+
+    Returns:
+        Decorator function.
+
+    Example:
+        @with_fallback(lambda symbol: {"price": 0.0}, on_error=log_error)
+        async def fetch_price(symbol: str) -> dict:
+            return await market_api.get_price(symbol)
+    """
+
+    def decorator(fn: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            try:
+                return await fn(*args, **kwargs)
+            except Exception as e:
+                if on_error:
+                    on_error(e)
+
+                logger.warning(
+                    "fallback_activated",
+                    function=fn.__name__,
+                    error=str(e),
+                )
+
+                fallback_result = fallback_fn(*args, **kwargs)
+                if asyncio.iscoroutine(fallback_result):
+                    return cast(T, await fallback_result)
+                return cast(T, fallback_result)
+
+        return wrapper
+
+    return decorator
+
+
+class FallbackChain(Generic[T]):
+    """Chain of fallback data sources.
+
+    Tries each source in order until one succeeds.
+
+    Example:
+        chain = FallbackChain[dict]()
+        chain.add("primary", fetch_from_api)
+        chain.add("cache", fetch_from_cache)
+        chain.add("mock", lambda: {"price": 0.0})
+
+        result, source = await chain.execute()
+    """
+
+    def __init__(self) -> None:
+        """Initialize fallback chain."""
+        self._sources: list[tuple[str, Callable[[], Awaitable[T] | T]]] = []
+
+    def add(self, name: str, source: Callable[[], Awaitable[T] | T]) -> "FallbackChain[T]":
+        """Add a fallback source.
+
+        Args:
+            name: Name of the source for logging.
+            source: Callable that returns data.
+
+        Returns:
+            Self for chaining.
+        """
+        self._sources.append((name, source))
+        return self
+
+    async def execute(self) -> tuple[T, str]:
+        """Execute the fallback chain.
+
+        Tries each source in order until one succeeds.
+
+        Returns:
+            Tuple of (result, source_name).
+
+        Raises:
+            RuntimeError: If all sources fail.
+        """
+        errors: list[tuple[str, Exception]] = []
+
+        for name, source in self._sources:
+            try:
+                source_result = source()
+                if asyncio.iscoroutine(source_result):
+                    source_result = await source_result
+
+                logger.debug("fallback_chain_success", source=name)
+                return cast(T, source_result), name
+
+            except Exception as e:
+                errors.append((name, e))
+                logger.debug(
+                    "fallback_chain_source_failed",
+                    source=name,
+                    error=str(e),
+                )
+                continue
+
+        # All sources failed
+        error_summary = "; ".join(f"{name}: {e}" for name, e in errors)
+        raise RuntimeError(f"All fallback sources failed: {error_summary}")
+
+
+# Global degradation manager instance
+_degradation_manager: DegradationManager | None = None
+
+
+def get_degradation_manager() -> DegradationManager | None:
+    """Get the global degradation manager instance.
+
+    Returns:
+        Degradation manager or None if not initialized.
+    """
+    return _degradation_manager
+
+
+def set_degradation_manager(manager: DegradationManager) -> None:
+    """Set the global degradation manager instance.
+
+    Args:
+        manager: Degradation manager to set as global.
+    """
+    global _degradation_manager
+    _degradation_manager = manager
+
+
+def reset_degradation_manager() -> None:
+    """Reset the global degradation manager (for testing)."""
+    global _degradation_manager
+    _degradation_manager = None

--- a/tests/test_resilience/test_degradation.py
+++ b/tests/test_resilience/test_degradation.py
@@ -1,0 +1,692 @@
+"""Tests for graceful degradation module."""
+
+import asyncio
+
+import pytest
+
+from src.resilience.degradation import (
+    ComponentHealth,
+    ComponentStatus,
+    ComponentType,
+    DegradationLevel,
+    DegradationManager,
+    DegradationMetrics,
+    DegradationStrategy,
+    DegradedResponse,
+    FallbackChain,
+    get_degradation_manager,
+    reset_degradation_manager,
+    set_degradation_manager,
+    with_fallback,
+)
+
+
+class TestDegradationLevel:
+    """Tests for DegradationLevel enum."""
+
+    def test_full_is_not_degraded(self) -> None:
+        """FULL level should not be degraded."""
+        assert not DegradationLevel.FULL.is_degraded()
+
+    def test_other_levels_are_degraded(self) -> None:
+        """All non-FULL levels should be degraded."""
+        assert DegradationLevel.CACHED_DATA.is_degraded()
+        assert DegradationLevel.MOCK_DATA.is_degraded()
+        assert DegradationLevel.BASIC_ANALYSIS.is_degraded()
+        assert DegradationLevel.RECOMMENDATIONS_ONLY.is_degraded()
+        assert DegradationLevel.UNAVAILABLE.is_degraded()
+
+    def test_severity_ordering(self) -> None:
+        """Severity should increase with worse degradation."""
+        assert DegradationLevel.FULL.severity() < DegradationLevel.CACHED_DATA.severity()
+        assert DegradationLevel.CACHED_DATA.severity() < DegradationLevel.MOCK_DATA.severity()
+        assert DegradationLevel.MOCK_DATA.severity() < DegradationLevel.BASIC_ANALYSIS.severity()
+        assert (
+            DegradationLevel.BASIC_ANALYSIS.severity()
+            < DegradationLevel.RECOMMENDATIONS_ONLY.severity()
+        )
+        assert (
+            DegradationLevel.RECOMMENDATIONS_ONLY.severity()
+            < DegradationLevel.UNAVAILABLE.severity()
+        )
+
+
+class TestComponentStatus:
+    """Tests for ComponentStatus."""
+
+    def test_initial_state(self) -> None:
+        """New status should have unknown health."""
+        status = ComponentStatus(component=ComponentType.MARKET_DATA_API)
+        assert status.health == ComponentHealth.UNKNOWN
+        assert status.failure_count == 0
+        assert status.error_message is None
+
+    def test_mark_healthy(self) -> None:
+        """Marking healthy should update status."""
+        status = ComponentStatus(component=ComponentType.MARKET_DATA_API)
+        status.mark_unhealthy("Error")
+        status.mark_healthy()
+
+        assert status.health == ComponentHealth.HEALTHY
+        assert status.failure_count == 0
+        assert status.error_message is None
+        assert status.last_healthy is not None
+
+    def test_mark_unhealthy(self) -> None:
+        """Marking unhealthy should track failures."""
+        status = ComponentStatus(component=ComponentType.LLM)
+        status.mark_unhealthy("Connection timeout")
+        status.mark_unhealthy("Connection refused")
+
+        assert status.health == ComponentHealth.UNHEALTHY
+        assert status.failure_count == 2
+        assert status.error_message == "Connection refused"
+
+    def test_mark_degraded(self) -> None:
+        """Marking degraded should set appropriate state."""
+        status = ComponentStatus(component=ComponentType.REDIS)
+        status.mark_degraded("High latency")
+
+        assert status.health == ComponentHealth.DEGRADED
+        assert status.error_message == "High latency"
+
+    def test_is_available(self) -> None:
+        """Available should be true for healthy or degraded."""
+        status = ComponentStatus(component=ComponentType.POSTGRES)
+
+        status.mark_healthy()
+        assert status.is_available()
+
+        status.mark_degraded()
+        assert status.is_available()
+
+        status.mark_unhealthy()
+        assert not status.is_available()
+
+    def test_to_dict(self) -> None:
+        """Should convert to dictionary."""
+        status = ComponentStatus(component=ComponentType.NEWS_API)
+        status.mark_healthy()
+
+        data = status.to_dict()
+        assert data["component"] == "news_api"
+        assert data["health"] == "healthy"
+        assert "last_check" in data
+        assert data["failure_count"] == 0
+
+
+class TestDegradedResponse:
+    """Tests for DegradedResponse."""
+
+    def test_default_values(self) -> None:
+        """Should have sensible defaults."""
+        response: DegradedResponse[str] = DegradedResponse(result="data")
+        assert response.result == "data"
+        assert response.degradation_level == DegradationLevel.FULL
+        assert response.warnings == []
+        assert response.cache_age_seconds is None
+        assert not response.is_degraded()
+
+    def test_degraded_response(self) -> None:
+        """Should track degradation state."""
+        response: DegradedResponse[dict[str, int]] = DegradedResponse(
+            result={"value": 42},
+            degradation_level=DegradationLevel.CACHED_DATA,
+            warnings=["Using cached data"],
+            cache_age_seconds=120.5,
+        )
+
+        assert response.is_degraded()
+        assert len(response.warnings) == 1
+        assert response.cache_age_seconds == 120.5
+
+    def test_add_warning(self) -> None:
+        """Should add warnings."""
+        response: DegradedResponse[str] = DegradedResponse(result="data")
+        response.add_warning("Warning 1")
+        response.add_warning("Warning 2")
+
+        assert len(response.warnings) == 2
+        assert "Warning 1" in response.warnings
+
+    def test_to_dict(self) -> None:
+        """Should convert to dictionary."""
+        response: DegradedResponse[str] = DegradedResponse(
+            result="test",
+            degradation_level=DegradationLevel.MOCK_DATA,
+        )
+
+        data = response.to_dict()
+        assert data["result"] == "test"
+        assert data["degradation_level"] == "mock_data"
+        assert "timestamp" in data
+
+
+class TestDegradationMetrics:
+    """Tests for DegradationMetrics."""
+
+    @pytest.fixture
+    def metrics(self) -> DegradationMetrics:
+        """Create fresh metrics."""
+        return DegradationMetrics()
+
+    @pytest.mark.asyncio
+    async def test_record_degradation(self, metrics: DegradationMetrics) -> None:
+        """Should record degradation events."""
+        await metrics.record_degradation(DegradationLevel.FULL)
+        await metrics.record_degradation(DegradationLevel.CACHED_DATA)
+        await metrics.record_degradation(DegradationLevel.CACHED_DATA)
+
+        assert metrics.degradation_events[DegradationLevel.FULL] == 1
+        assert metrics.degradation_events[DegradationLevel.CACHED_DATA] == 2
+        assert metrics.total_full_requests == 1
+        assert metrics.total_degraded_requests == 2
+
+    @pytest.mark.asyncio
+    async def test_record_component_failure(self, metrics: DegradationMetrics) -> None:
+        """Should record component failures."""
+        await metrics.record_component_failure(ComponentType.LLM)
+        await metrics.record_component_failure(ComponentType.LLM)
+        await metrics.record_component_failure(ComponentType.REDIS)
+
+        assert metrics.component_failures[ComponentType.LLM] == 2
+        assert metrics.component_failures[ComponentType.REDIS] == 1
+
+    @pytest.mark.asyncio
+    async def test_degraded_ratio(self, metrics: DegradationMetrics) -> None:
+        """Should calculate degraded ratio."""
+        assert metrics.degraded_ratio == 0.0
+
+        await metrics.record_degradation(DegradationLevel.FULL)
+        await metrics.record_degradation(DegradationLevel.FULL)
+        await metrics.record_degradation(DegradationLevel.CACHED_DATA)
+        await metrics.record_degradation(DegradationLevel.MOCK_DATA)
+
+        assert metrics.degraded_ratio == 0.5  # 2 degraded out of 4
+
+    def test_reset(self, metrics: DegradationMetrics) -> None:
+        """Should reset all metrics."""
+        metrics.total_degraded_requests = 100
+        metrics.total_full_requests = 200
+        metrics.reset()
+
+        assert metrics.total_degraded_requests == 0
+        assert metrics.total_full_requests == 0
+        assert all(v == 0 for v in metrics.degradation_events.values())
+
+    @pytest.mark.asyncio
+    async def test_to_dict(self, metrics: DegradationMetrics) -> None:
+        """Should convert to dictionary."""
+        await metrics.record_degradation(DegradationLevel.BASIC_ANALYSIS)
+
+        data = metrics.to_dict()
+        assert "degradation_events" in data
+        assert "component_failures" in data
+        assert "degraded_ratio" in data
+
+
+class TestDegradationStrategy:
+    """Tests for DegradationStrategy."""
+
+    def test_default_strategy(self) -> None:
+        """Should use default mappings."""
+        strategy = DegradationStrategy()
+
+        # Market data failure -> cached data
+        level = strategy.get_degradation_level({ComponentType.MARKET_DATA_API})
+        assert level == DegradationLevel.CACHED_DATA
+
+        # LLM failure -> basic analysis
+        level = strategy.get_degradation_level({ComponentType.LLM})
+        assert level == DegradationLevel.BASIC_ANALYSIS
+
+    def test_no_failures_returns_full(self) -> None:
+        """Should return FULL when no components failed."""
+        strategy = DegradationStrategy()
+        level = strategy.get_degradation_level(set())
+        assert level == DegradationLevel.FULL
+
+    def test_multiple_failures_returns_worst(self) -> None:
+        """Should return worst degradation level."""
+        strategy = DegradationStrategy()
+
+        # Market data (cached) + LLM (basic analysis) -> basic analysis (worse)
+        level = strategy.get_degradation_level(
+            {ComponentType.MARKET_DATA_API, ComponentType.LLM}
+        )
+        assert level == DegradationLevel.BASIC_ANALYSIS
+
+    def test_custom_degradation_map(self) -> None:
+        """Should use custom degradation mapping."""
+        custom_map = {
+            ComponentType.REDIS: DegradationLevel.UNAVAILABLE,
+        }
+        strategy = DegradationStrategy(degradation_map=custom_map)
+
+        level = strategy.get_degradation_level({ComponentType.REDIS})
+        assert level == DegradationLevel.UNAVAILABLE
+
+    def test_get_warnings(self) -> None:
+        """Should return warnings for failed components."""
+        strategy = DegradationStrategy()
+
+        warnings = strategy.get_warnings({ComponentType.MARKET_DATA_API, ComponentType.LLM})
+        assert len(warnings) == 2
+        assert any("market data" in w.lower() for w in warnings)
+        assert any("analysis" in w.lower() for w in warnings)
+
+    def test_get_warnings_empty_for_no_failures(self) -> None:
+        """Should return empty list when no failures."""
+        strategy = DegradationStrategy()
+        warnings = strategy.get_warnings(set())
+        assert warnings == []
+
+
+class TestDegradationManager:
+    """Tests for DegradationManager."""
+
+    @pytest.fixture
+    def manager(self) -> DegradationManager:
+        """Create fresh manager."""
+        return DegradationManager()
+
+    @pytest.mark.asyncio
+    async def test_initial_state(self, manager: DegradationManager) -> None:
+        """Should start at FULL degradation."""
+        assert manager.get_degradation_level() == DegradationLevel.FULL
+
+    @pytest.mark.asyncio
+    async def test_mark_healthy(self, manager: DegradationManager) -> None:
+        """Should mark component healthy."""
+        await manager.mark_healthy(ComponentType.MARKET_DATA_API)
+
+        status = manager.get_component_status(ComponentType.MARKET_DATA_API)
+        assert status.health == ComponentHealth.HEALTHY
+        assert manager.get_degradation_level() == DegradationLevel.FULL
+
+    @pytest.mark.asyncio
+    async def test_mark_unhealthy_degrades(self, manager: DegradationManager) -> None:
+        """Should degrade when component fails."""
+        await manager.mark_unhealthy(ComponentType.LLM, "Rate limited")
+
+        assert manager.get_degradation_level() == DegradationLevel.BASIC_ANALYSIS
+        status = manager.get_component_status(ComponentType.LLM)
+        assert status.failure_count == 1
+
+    @pytest.mark.asyncio
+    async def test_mark_degraded(self, manager: DegradationManager) -> None:
+        """Should handle degraded component."""
+        await manager.mark_degraded(ComponentType.REDIS, "High latency")
+
+        status = manager.get_component_status(ComponentType.REDIS)
+        assert status.health == ComponentHealth.DEGRADED
+        # Degraded is still available, so no level change
+        assert manager.get_degradation_level() == DegradationLevel.FULL
+
+    @pytest.mark.asyncio
+    async def test_recovery(self, manager: DegradationManager) -> None:
+        """Should recover when component becomes healthy."""
+        await manager.mark_unhealthy(ComponentType.NEWS_API)
+        assert manager.get_degradation_level().is_degraded()
+
+        await manager.mark_healthy(ComponentType.NEWS_API)
+        assert manager.get_degradation_level() == DegradationLevel.FULL
+
+    @pytest.mark.asyncio
+    async def test_get_failed_components(self, manager: DegradationManager) -> None:
+        """Should track failed components."""
+        assert manager.get_failed_components() == set()
+
+        await manager.mark_unhealthy(ComponentType.LLM)
+        await manager.mark_unhealthy(ComponentType.REDIS)
+
+        failed = manager.get_failed_components()
+        assert ComponentType.LLM in failed
+        assert ComponentType.REDIS in failed
+
+    @pytest.mark.asyncio
+    async def test_wrap_response(self, manager: DegradationManager) -> None:
+        """Should wrap response with degradation info."""
+        await manager.mark_unhealthy(ComponentType.MARKET_DATA_API)
+
+        response = manager.wrap_response({"price": 100.0}, cache_age=120)
+
+        assert response.result == {"price": 100.0}
+        assert response.degradation_level == DegradationLevel.CACHED_DATA
+        assert len(response.warnings) >= 1
+        assert response.cache_age_seconds == 120
+
+    @pytest.mark.asyncio
+    async def test_wrap_response_adds_cache_warning(
+        self, manager: DegradationManager
+    ) -> None:
+        """Should add warning for old cache data."""
+        response = manager.wrap_response("data", cache_age=300)
+
+        assert any("cache" in w.lower() for w in response.warnings)
+
+    @pytest.mark.asyncio
+    async def test_alert_callback(self) -> None:
+        """Should trigger alert on degradation."""
+        alerts: list[tuple[DegradationLevel, list[str]]] = []
+
+        async def alert_handler(
+            level: DegradationLevel, warnings: list[str]
+        ) -> None:
+            alerts.append((level, warnings))
+
+        manager = DegradationManager(alert_callback=alert_handler)
+        await manager.mark_unhealthy(ComponentType.LLM)
+
+        assert len(alerts) == 1
+        assert alerts[0][0] == DegradationLevel.BASIC_ANALYSIS
+
+    @pytest.mark.asyncio
+    async def test_no_alert_on_recovery(self) -> None:
+        """Should not alert when recovering."""
+        alerts: list[tuple[DegradationLevel, list[str]]] = []
+
+        async def alert_handler(
+            level: DegradationLevel, warnings: list[str]
+        ) -> None:
+            alerts.append((level, warnings))
+
+        manager = DegradationManager(alert_callback=alert_handler)
+        await manager.mark_unhealthy(ComponentType.LLM)
+        alerts.clear()
+
+        await manager.mark_healthy(ComponentType.LLM)
+        assert len(alerts) == 0  # No alert on recovery
+
+    @pytest.mark.asyncio
+    async def test_get_health_summary(self, manager: DegradationManager) -> None:
+        """Should return health summary."""
+        await manager.mark_unhealthy(ComponentType.NEWS_API, "Timeout")
+
+        summary = manager.get_health_summary()
+        assert summary["degradation_level"] == "cached_data"
+        assert summary["is_degraded"] is True
+        assert "news_api" in summary["failed_components"]
+        assert "components" in summary
+        assert "metrics" in summary
+
+    @pytest.mark.asyncio
+    async def test_get_all_component_statuses(
+        self, manager: DegradationManager
+    ) -> None:
+        """Should return all component statuses."""
+        statuses = manager.get_all_component_statuses()
+        assert len(statuses) == len(ComponentType)
+        assert all(isinstance(s, ComponentStatus) for s in statuses.values())
+
+    @pytest.mark.asyncio
+    async def test_metrics_tracking(self, manager: DegradationManager) -> None:
+        """Should track metrics."""
+        await manager.mark_unhealthy(ComponentType.LLM)
+        await manager.mark_unhealthy(ComponentType.LLM)
+
+        metrics = manager.get_metrics()
+        assert metrics["component_failures"]["llm"] == 2
+
+    def test_reset_metrics(self, manager: DegradationManager) -> None:
+        """Should reset metrics."""
+        manager.metrics.total_degraded_requests = 100
+        manager.reset_metrics()
+        assert manager.metrics.total_degraded_requests == 0
+
+
+class TestWithFallback:
+    """Tests for with_fallback decorator."""
+
+    @pytest.mark.asyncio
+    async def test_returns_primary_on_success(self) -> None:
+        """Should return primary result when successful."""
+
+        @with_fallback(lambda x: "fallback")  # noqa: ARG005
+        async def fetch_data(x: int) -> str:
+            return f"data-{x}"
+
+        result = await fetch_data(42)
+        assert result == "data-42"
+
+    @pytest.mark.asyncio
+    async def test_returns_fallback_on_error(self) -> None:
+        """Should return fallback on error."""
+
+        @with_fallback(lambda x: f"fallback-{x}")
+        async def fetch_data(x: int) -> str:  # noqa: ARG001
+            raise ConnectionError("API down")
+
+        result = await fetch_data(42)
+        assert result == "fallback-42"
+
+    @pytest.mark.asyncio
+    async def test_calls_on_error_callback(self) -> None:
+        """Should call on_error callback."""
+        errors: list[Exception] = []
+
+        @with_fallback(lambda: "fallback", on_error=lambda e: errors.append(e))
+        async def fetch_data() -> str:
+            raise ValueError("Bad value")
+
+        await fetch_data()
+        assert len(errors) == 1
+        assert isinstance(errors[0], ValueError)
+
+    @pytest.mark.asyncio
+    async def test_async_fallback(self) -> None:
+        """Should handle async fallback function."""
+
+        async def async_fallback(x: int) -> str:
+            await asyncio.sleep(0)
+            return f"async-fallback-{x}"
+
+        @with_fallback(async_fallback)
+        async def fetch_data(x: int) -> str:  # noqa: ARG001
+            raise RuntimeError("Error")
+
+        result = await fetch_data(5)
+        assert result == "async-fallback-5"
+
+
+class TestFallbackChain:
+    """Tests for FallbackChain."""
+
+    @pytest.mark.asyncio
+    async def test_returns_first_success(self) -> None:
+        """Should return result from first successful source."""
+        chain: FallbackChain[str] = FallbackChain()
+        chain.add("primary", lambda: "primary-data")
+        chain.add("secondary", lambda: "secondary-data")
+
+        result, source = await chain.execute()
+        assert result == "primary-data"
+        assert source == "primary"
+
+    @pytest.mark.asyncio
+    async def test_falls_through_on_error(self) -> None:
+        """Should try next source on error."""
+
+        def failing_source() -> str:
+            raise ConnectionError("Down")
+
+        chain: FallbackChain[str] = FallbackChain()
+        chain.add("primary", failing_source)
+        chain.add("secondary", lambda: "secondary-data")
+
+        result, source = await chain.execute()
+        assert result == "secondary-data"
+        assert source == "secondary"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_all_fail(self) -> None:
+        """Should raise when all sources fail."""
+
+        def failing() -> str:
+            raise RuntimeError("Fail")
+
+        chain: FallbackChain[str] = FallbackChain()
+        chain.add("source1", failing)
+        chain.add("source2", failing)
+
+        with pytest.raises(RuntimeError, match="All fallback sources failed"):
+            await chain.execute()
+
+    @pytest.mark.asyncio
+    async def test_async_sources(self) -> None:
+        """Should handle async sources."""
+
+        async def async_source() -> str:
+            await asyncio.sleep(0)
+            return "async-data"
+
+        chain: FallbackChain[str] = FallbackChain()
+        chain.add("async", async_source)
+
+        result, source = await chain.execute()
+        assert result == "async-data"
+        assert source == "async"
+
+    @pytest.mark.asyncio
+    async def test_chaining_api(self) -> None:
+        """Should support method chaining."""
+        chain = (
+            FallbackChain[int]()
+            .add("a", lambda: 1)
+            .add("b", lambda: 2)
+            .add("c", lambda: 3)
+        )
+
+        result, _ = await chain.execute()
+        assert result == 1
+
+
+class TestGlobalManager:
+    """Tests for global manager functions."""
+
+    def test_initial_state(self) -> None:
+        """Should be None initially."""
+        reset_degradation_manager()
+        assert get_degradation_manager() is None
+
+    def test_set_and_get(self) -> None:
+        """Should set and get manager."""
+        reset_degradation_manager()
+        manager = DegradationManager()
+        set_degradation_manager(manager)
+
+        assert get_degradation_manager() is manager
+
+    def test_reset(self) -> None:
+        """Should reset manager."""
+        manager = DegradationManager()
+        set_degradation_manager(manager)
+        reset_degradation_manager()
+
+        assert get_degradation_manager() is None
+
+
+class TestConcurrency:
+    """Tests for thread safety."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_status_updates(self) -> None:
+        """Should handle concurrent status updates."""
+        manager = DegradationManager()
+
+        async def update_component(comp: ComponentType) -> None:
+            for _ in range(10):
+                await manager.mark_unhealthy(comp)
+                await manager.mark_healthy(comp)
+
+        await asyncio.gather(
+            *[update_component(comp) for comp in ComponentType]
+        )
+
+        # Should not raise, final state depends on timing
+
+    @pytest.mark.asyncio
+    async def test_concurrent_metrics_recording(self) -> None:
+        """Should handle concurrent metrics updates."""
+        metrics = DegradationMetrics()
+
+        async def record_events() -> None:
+            for _ in range(100):
+                await metrics.record_degradation(DegradationLevel.CACHED_DATA)
+                await metrics.record_component_failure(ComponentType.LLM)
+
+        await asyncio.gather(*[record_events() for _ in range(10)])
+
+        # 10 tasks * 100 iterations = 1000 events
+        assert metrics.total_degraded_requests == 1000
+        assert metrics.component_failures[ComponentType.LLM] == 1000
+
+
+class TestIntegration:
+    """Integration tests for graceful degradation."""
+
+    @pytest.mark.asyncio
+    async def test_full_degradation_flow(self) -> None:
+        """Test complete degradation and recovery flow."""
+        alerts: list[DegradationLevel] = []
+
+        async def on_alert(
+            level: DegradationLevel, warnings: list[str]  # noqa: ARG001
+        ) -> None:
+            alerts.append(level)
+
+        manager = DegradationManager(alert_callback=on_alert)
+
+        # Start healthy
+        await manager.mark_healthy(ComponentType.MARKET_DATA_API)
+        await manager.mark_healthy(ComponentType.LLM)
+        assert manager.get_degradation_level() == DegradationLevel.FULL
+
+        # Market data fails -> cached data mode
+        await manager.mark_unhealthy(ComponentType.MARKET_DATA_API, "API timeout")
+        assert manager.get_degradation_level() == DegradationLevel.CACHED_DATA
+        response = manager.wrap_response({"symbol": "AAPL"})
+        assert response.is_degraded()
+        assert len(response.warnings) >= 1
+
+        # LLM also fails -> basic analysis (worse)
+        await manager.mark_unhealthy(ComponentType.LLM, "Rate limited")
+        assert manager.get_degradation_level() == DegradationLevel.BASIC_ANALYSIS
+
+        # Market data recovers, but LLM still down
+        await manager.mark_healthy(ComponentType.MARKET_DATA_API)
+        assert manager.get_degradation_level() == DegradationLevel.BASIC_ANALYSIS
+
+        # LLM recovers -> full service
+        await manager.mark_healthy(ComponentType.LLM)
+        assert manager.get_degradation_level() == DegradationLevel.FULL
+
+        # Check alerts were triggered
+        assert DegradationLevel.CACHED_DATA in alerts
+        assert DegradationLevel.BASIC_ANALYSIS in alerts
+
+    @pytest.mark.asyncio
+    async def test_fallback_chain_with_degradation(self) -> None:
+        """Test fallback chain updates degradation manager."""
+        manager = DegradationManager()
+
+        # Simulate fetching market data with fallbacks
+        chain: FallbackChain[dict[str, float]] = FallbackChain()
+
+        def api_fetch() -> dict[str, float]:
+            raise ConnectionError("API down")
+
+        def cache_fetch() -> dict[str, float]:
+            return {"price": 150.0, "cached": True}
+
+        chain.add("api", api_fetch)
+        chain.add("cache", cache_fetch)
+
+        result, source = await chain.execute()
+
+        # Update degradation based on source
+        if source != "api":
+            await manager.mark_unhealthy(ComponentType.MARKET_DATA_API)
+
+        assert result["price"] == 150.0
+        assert manager.get_degradation_level() == DegradationLevel.CACHED_DATA


### PR DESCRIPTION
## Summary
- Implements graceful degradation for service continuity during partial outages
- Adds component health tracking with automatic degradation level calculation
- Provides fallback mechanisms with `with_fallback` decorator and `FallbackChain`
- Includes user-facing warnings about degraded service state

## Changes
- Added `src/resilience/degradation.py` with:
  - `DegradationLevel` enum (FULL → UNAVAILABLE)
  - `ComponentType` and `ComponentHealth` for tracking
  - `DegradationManager` for coordinating degradation
  - `DegradationStrategy` for mapping failures to levels
  - `DegradedResponse` wrapper with warnings
  - `with_fallback` decorator for automatic fallback
  - `FallbackChain` for multi-source fallbacks
  - Metrics tracking for observability
- Updated `src/resilience/__init__.py` with exports
- Added 54 comprehensive tests

## Test plan
- [x] All 54 tests pass
- [x] Linting passes (ruff)
- [x] Type checking passes (mypy)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)