### PR TITLE
feat: Add end-to-end Langfuse tracing integration (#21)

### DIFF
--- a/src/orchestration/workflow.py
+++ b/src/orchestration/workflow.py
@@ -11,6 +11,9 @@ from langgraph.graph import END, StateGraph
 
 from src.agents import AnalysisAgent, RecommendationAgent, ResearchAgent
 from src.agents.base import AgentState
+from langfuse import observe
+
+from src.observability.tracing import traced_agent
 from src.orchestration.state import (
     AgentName,
     PortfolioState,
@@ -29,6 +32,7 @@ logger = structlog.get_logger(__name__)
 # ============================================================================
 
 
+@traced_agent("research_agent")
 async def research_node(state: PortfolioState) -> PortfolioState:
     """Execute the research agent.
 
@@ -94,6 +98,7 @@ async def research_node(state: PortfolioState) -> PortfolioState:
     return state
 
 
+@traced_agent("analysis_agent")
 async def analysis_node(state: PortfolioState) -> PortfolioState:
     """Execute the analysis agent.
 
@@ -163,6 +168,7 @@ async def analysis_node(state: PortfolioState) -> PortfolioState:
     return state
 
 
+@traced_agent("recommendation_agent")
 async def recommendation_node(state: PortfolioState) -> PortfolioState:
     """Execute the recommendation agent.
 
@@ -238,6 +244,7 @@ async def recommendation_node(state: PortfolioState) -> PortfolioState:
     return state
 
 
+@observe(name="error_handler", as_type="span")
 async def error_handler_node(state: PortfolioState) -> PortfolioState:
     """Handle workflow errors.
 
@@ -266,6 +273,7 @@ async def error_handler_node(state: PortfolioState) -> PortfolioState:
     return state
 
 
+@observe(name="finalize", as_type="span")
 async def finalize_node(state: PortfolioState) -> PortfolioState:
     """Finalize the workflow.
 


### PR DESCRIPTION
## Summary

- Implements comprehensive Langfuse tracing integration for full observability
- Adds request-scoped TraceContext in API routes with portfolio metadata
- Decorates workflow agent nodes with @traced_agent for span tracking
- Adds trace scoring for completion success and latency quality metrics
- Links errors to traces for debugging failed requests

## Changes

### API Routes (`src/api/routes.py`)
- Added `TraceContext` for request-scoped attribute propagation
- Implemented `_run_traced_workflow` with `@observe` decorator
- Added `_score_trace` for success/latency scoring
- Added `_record_trace_error` for error linking
- Included portfolio metadata in traces (symbols, account type)

### Workflow (`src/orchestration/workflow.py`)
- Added `@traced_agent("research_agent")` to `research_node`
- Added `@traced_agent("analysis_agent")` to `analysis_node`
- Added `@traced_agent("recommendation_agent")` to `recommendation_node`
- Added `@observe` spans for `error_handler_node` and `finalize_node`

### Trace Hierarchy
```
Request trace → portfolio_workflow span
  ├── research_agent span
  ├── analysis_agent span
  ├── recommendation_agent span
  └── finalize/error_handler span
```

## Test Plan

- [x] All 811 existing tests pass
- [x] Tracing decorators work transparently without affecting functionality
- [x] API endpoints properly create and score traces
- [x] Error handling correctly records failures to traces

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)