### PR TITLE
feat: Add error handling and recovery system (#20)

### DIFF
--- a/src/orchestration/__init__.py
+++ b/src/orchestration/__init__.py
@@ -6,6 +6,30 @@ This module contains:
 - Error handling and recovery
 """
 
+from src.orchestration.errors import (
+    AGENT_FALLBACK_CONFIGS,
+    AgentError,
+    AgentFallbackConfig,
+    ErrorRecoveryManager,
+    FallbackResult,
+    FallbackType,
+    PortfolioAdvisorError,
+    RecoveryAttempt,
+    RecoveryContext,
+    RecoveryError,
+    RetryConfig,
+    RetryStrategy,
+    StateError,
+    ToolError,
+    WorkflowTimeoutError,
+    classify_error,
+    execute_with_timeout,
+    get_agent_fallback_config,
+    get_recovery_manager,
+    is_critical_error,
+    reset_recovery_manager,
+    with_retry,
+)
 from src.orchestration.state import (
     AgentName,
     AnalysisOutputDict,
@@ -43,6 +67,29 @@ from src.orchestration.workflow import (
 )
 
 __all__ = [
+    # Error handling exports
+    "AGENT_FALLBACK_CONFIGS",
+    "AgentError",
+    "AgentFallbackConfig",
+    "ErrorRecoveryManager",
+    "FallbackResult",
+    "FallbackType",
+    "PortfolioAdvisorError",
+    "RecoveryAttempt",
+    "RecoveryContext",
+    "RecoveryError",
+    "RetryConfig",
+    "RetryStrategy",
+    "StateError",
+    "ToolError",
+    "WorkflowTimeoutError",
+    "classify_error",
+    "execute_with_timeout",
+    "get_agent_fallback_config",
+    "get_recovery_manager",
+    "is_critical_error",
+    "reset_recovery_manager",
+    "with_retry",
     # State exports
     "AgentName",
     "AnalysisOutputDict",

--- a/src/orchestration/errors.py
+++ b/src/orchestration/errors.py
@@ -1,0 +1,757 @@
+"""Error handling and recovery for multi-agent workflows.
+
+This module provides:
+- Custom exception hierarchy for workflow errors
+- Retry logic with exponential backoff
+- Fallback strategies per agent
+- Recovery patterns for graceful degradation
+
+Exception Hierarchy:
+    PortfolioAdvisorError (base)
+    ├── AgentError - Agent execution failures
+    ├── ToolError - Tool execution failures
+    ├── StateError - State validation failures
+    ├── WorkflowTimeoutError - Operation timeouts
+    └── RecoveryError - Recovery attempt failures
+"""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from functools import wraps
+from typing import Any, ParamSpec, TypeVar
+
+import structlog
+from tenacity import (
+    AsyncRetrying,
+    RetryError,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = structlog.get_logger(__name__)
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+# ============================================================================
+# Exception Hierarchy
+# ============================================================================
+
+
+class PortfolioAdvisorError(Exception):
+    """Base exception for all Portfolio Advisor errors.
+
+    Attributes:
+        message: Human-readable error message.
+        details: Additional error details.
+        recoverable: Whether the error can be recovered from.
+        trace_id: Optional trace ID for observability.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        details: dict[str, Any] | None = None,
+        recoverable: bool = True,
+        trace_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.details = details or {}
+        self.recoverable = recoverable
+        self.trace_id = trace_id
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert exception to dictionary for logging/API responses."""
+        return {
+            "error_type": self.__class__.__name__,
+            "message": self.message,
+            "details": self.details,
+            "recoverable": self.recoverable,
+            "trace_id": self.trace_id,
+        }
+
+
+class AgentError(PortfolioAdvisorError):
+    """Agent execution failed.
+
+    Raised when an agent encounters an error during execution.
+
+    Attributes:
+        agent_name: Name of the agent that failed.
+        stage: Stage of execution where failure occurred.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        agent_name: str,
+        stage: str = "execution",
+        details: dict[str, Any] | None = None,
+        recoverable: bool = True,
+        trace_id: str | None = None,
+    ) -> None:
+        super().__init__(
+            message, details=details, recoverable=recoverable, trace_id=trace_id
+        )
+        self.agent_name = agent_name
+        self.stage = stage
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        base = super().to_dict()
+        base.update({"agent_name": self.agent_name, "stage": self.stage})
+        return base
+
+
+class ToolError(PortfolioAdvisorError):
+    """Tool execution failed.
+
+    Raised when a tool encounters an error during execution.
+
+    Attributes:
+        tool_name: Name of the tool that failed.
+        input_data: Input that caused the failure (sanitized).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        tool_name: str,
+        input_data: dict[str, Any] | None = None,
+        details: dict[str, Any] | None = None,
+        recoverable: bool = True,
+        trace_id: str | None = None,
+    ) -> None:
+        super().__init__(
+            message, details=details, recoverable=recoverable, trace_id=trace_id
+        )
+        self.tool_name = tool_name
+        self.input_data = input_data or {}
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        base = super().to_dict()
+        base.update({"tool_name": self.tool_name, "input_data": self.input_data})
+        return base
+
+
+class StateError(PortfolioAdvisorError):
+    """State validation or persistence failed.
+
+    Raised when workflow state is invalid or cannot be persisted.
+
+    Attributes:
+        state_key: The state key that caused the error.
+        expected: Expected value/type (if applicable).
+        actual: Actual value/type found.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        state_key: str | None = None,
+        expected: str | None = None,
+        actual: str | None = None,
+        details: dict[str, Any] | None = None,
+        recoverable: bool = False,
+        trace_id: str | None = None,
+    ) -> None:
+        super().__init__(
+            message, details=details, recoverable=recoverable, trace_id=trace_id
+        )
+        self.state_key = state_key
+        self.expected = expected
+        self.actual = actual
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        base = super().to_dict()
+        base.update(
+            {"state_key": self.state_key, "expected": self.expected, "actual": self.actual}
+        )
+        return base
+
+
+class WorkflowTimeoutError(PortfolioAdvisorError):
+    """Operation timed out.
+
+    Raised when an operation exceeds its timeout limit.
+
+    Attributes:
+        timeout_seconds: The timeout that was exceeded.
+        operation: Name of the operation that timed out.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        timeout_seconds: float,
+        operation: str,
+        details: dict[str, Any] | None = None,
+        recoverable: bool = True,
+        trace_id: str | None = None,
+    ) -> None:
+        super().__init__(
+            message, details=details, recoverable=recoverable, trace_id=trace_id
+        )
+        self.timeout_seconds = timeout_seconds
+        self.operation = operation
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        base = super().to_dict()
+        base.update(
+            {"timeout_seconds": self.timeout_seconds, "operation": self.operation}
+        )
+        return base
+
+
+class RecoveryError(PortfolioAdvisorError):
+    """Recovery attempt failed.
+
+    Raised when error recovery fails after all retries/fallbacks.
+
+    Attributes:
+        original_error: The original error that triggered recovery.
+        recovery_attempts: Number of recovery attempts made.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        original_error: Exception | None = None,
+        recovery_attempts: int = 0,
+        details: dict[str, Any] | None = None,
+        trace_id: str | None = None,
+    ) -> None:
+        super().__init__(
+            message, details=details, recoverable=False, trace_id=trace_id
+        )
+        self.original_error = original_error
+        self.recovery_attempts = recovery_attempts
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        base = super().to_dict()
+        base.update(
+            {
+                "original_error": str(self.original_error) if self.original_error else None,
+                "recovery_attempts": self.recovery_attempts,
+            }
+        )
+        return base
+
+
+# ============================================================================
+# Retry Configuration
+# ============================================================================
+
+
+class RetryStrategy(Enum):
+    """Retry strategies for different scenarios."""
+
+    NONE = "none"  # No retries
+    QUICK = "quick"  # 2 retries, short backoff
+    STANDARD = "standard"  # 3 retries, standard backoff
+    PERSISTENT = "persistent"  # 5 retries, longer backoff
+
+
+@dataclass
+class RetryConfig:
+    """Configuration for retry behavior.
+
+    Attributes:
+        max_attempts: Maximum number of attempts (including initial).
+        min_wait_seconds: Minimum wait between retries.
+        max_wait_seconds: Maximum wait between retries.
+        multiplier: Exponential backoff multiplier.
+        retry_exceptions: Exception types to retry on.
+    """
+
+    max_attempts: int = 3
+    min_wait_seconds: float = 1.0
+    max_wait_seconds: float = 30.0
+    multiplier: float = 2.0
+    retry_exceptions: tuple[type[Exception], ...] = field(
+        default_factory=lambda: (AgentError, ToolError, WorkflowTimeoutError)
+    )
+
+    @classmethod
+    def from_strategy(cls, strategy: RetryStrategy) -> "RetryConfig":
+        """Create config from a strategy preset.
+
+        Args:
+            strategy: The retry strategy to use.
+
+        Returns:
+            RetryConfig for the strategy.
+        """
+        configs = {
+            RetryStrategy.NONE: cls(max_attempts=1),
+            RetryStrategy.QUICK: cls(
+                max_attempts=2, min_wait_seconds=0.5, max_wait_seconds=5.0
+            ),
+            RetryStrategy.STANDARD: cls(
+                max_attempts=3, min_wait_seconds=1.0, max_wait_seconds=30.0
+            ),
+            RetryStrategy.PERSISTENT: cls(
+                max_attempts=5, min_wait_seconds=2.0, max_wait_seconds=60.0
+            ),
+        }
+        return configs[strategy]
+
+
+def with_retry(
+    config: RetryConfig | RetryStrategy | None = None,
+    on_retry: Callable[[Exception, int], None] | None = None,
+) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
+    """Decorator for adding retry logic with exponential backoff.
+
+    Args:
+        config: Retry configuration or strategy preset.
+        on_retry: Optional callback called on each retry.
+
+    Returns:
+        Decorated function with retry logic.
+
+    Example:
+        @with_retry(RetryStrategy.STANDARD)
+        async def fetch_data():
+            return await api.get_data()
+
+        @with_retry(RetryConfig(max_attempts=5))
+        async def resilient_operation():
+            ...
+    """
+    if config is None:
+        retry_config = RetryConfig()
+    elif isinstance(config, RetryStrategy):
+        retry_config = RetryConfig.from_strategy(config)
+    else:
+        retry_config = config
+
+    def decorator(fn: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+        @wraps(fn)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            attempt = 0
+
+            async for attempt_context in AsyncRetrying(
+                stop=stop_after_attempt(retry_config.max_attempts),
+                wait=wait_exponential(
+                    multiplier=retry_config.multiplier,
+                    min=retry_config.min_wait_seconds,
+                    max=retry_config.max_wait_seconds,
+                ),
+                retry=retry_if_exception_type(retry_config.retry_exceptions),
+                reraise=True,
+            ):
+                with attempt_context:
+                    attempt += 1
+                    if attempt > 1:
+                        logger.info(
+                            "retry_attempt",
+                            function=fn.__name__,
+                            attempt=attempt,
+                            max_attempts=retry_config.max_attempts,
+                        )
+                        if on_retry and attempt_context.retry_state.outcome:
+                            exc = attempt_context.retry_state.outcome.exception()
+                            if exc:
+                                on_retry(exc, attempt)
+
+                    return await fn(*args, **kwargs)
+
+            # This should not be reached due to reraise=True
+            raise RuntimeError("Retry loop exited unexpectedly")
+
+        return wrapper
+
+    return decorator
+
+
+# ============================================================================
+# Fallback Strategies
+# ============================================================================
+
+
+class FallbackType(Enum):
+    """Types of fallback behaviors."""
+
+    CACHED_DATA = "cached_data"  # Use cached/stale data
+    MOCK_DATA = "mock_data"  # Use mock/default data
+    PARTIAL_RESULT = "partial_result"  # Return partial results
+    SKIP = "skip"  # Skip the operation entirely
+    ERROR = "error"  # Propagate the error
+
+
+@dataclass
+class FallbackResult:
+    """Result from a fallback operation.
+
+    Attributes:
+        value: The fallback value.
+        fallback_type: Type of fallback used.
+        original_error: The error that triggered fallback.
+        warning: Warning message for the user.
+    """
+
+    value: Any
+    fallback_type: FallbackType
+    original_error: Exception | None = None
+    warning: str | None = None
+
+    @property
+    def is_fallback(self) -> bool:
+        """Check if this is a fallback result."""
+        return True
+
+
+@dataclass
+class AgentFallbackConfig:
+    """Fallback configuration for an agent.
+
+    Attributes:
+        agent_name: Name of the agent.
+        fallback_type: Type of fallback to use.
+        fallback_fn: Function to generate fallback data.
+        warning_message: Warning to show when fallback is used.
+        max_retries: Maximum retries before fallback.
+    """
+
+    agent_name: str
+    fallback_type: FallbackType = FallbackType.PARTIAL_RESULT
+    fallback_fn: Callable[..., Any] | None = None
+    warning_message: str | None = None
+    max_retries: int = 3
+
+
+# Default fallback configurations per agent
+AGENT_FALLBACK_CONFIGS: dict[str, AgentFallbackConfig] = {
+    "research_agent": AgentFallbackConfig(
+        agent_name="research_agent",
+        fallback_type=FallbackType.CACHED_DATA,
+        warning_message="Using cached market data; prices may be outdated",
+        max_retries=3,
+    ),
+    "analysis_agent": AgentFallbackConfig(
+        agent_name="analysis_agent",
+        fallback_type=FallbackType.PARTIAL_RESULT,
+        warning_message="Using simplified analysis; some metrics unavailable",
+        max_retries=2,
+    ),
+    "recommendation_agent": AgentFallbackConfig(
+        agent_name="recommendation_agent",
+        fallback_type=FallbackType.PARTIAL_RESULT,
+        warning_message="Providing conservative recommendations due to data limitations",
+        max_retries=2,
+    ),
+}
+
+
+def get_agent_fallback_config(agent_name: str) -> AgentFallbackConfig:
+    """Get fallback configuration for an agent.
+
+    Args:
+        agent_name: Name of the agent.
+
+    Returns:
+        Fallback configuration for the agent.
+    """
+    return AGENT_FALLBACK_CONFIGS.get(
+        agent_name,
+        AgentFallbackConfig(
+            agent_name=agent_name,
+            fallback_type=FallbackType.ERROR,
+            max_retries=1,
+        ),
+    )
+
+
+# ============================================================================
+# Error Recovery
+# ============================================================================
+
+
+@dataclass
+class RecoveryAttempt:
+    """Record of a recovery attempt.
+
+    Attributes:
+        timestamp: When the attempt was made.
+        strategy: Recovery strategy used.
+        success: Whether recovery succeeded.
+        error: Error if recovery failed.
+    """
+
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+    strategy: str = ""
+    success: bool = False
+    error: str | None = None
+
+
+@dataclass
+class RecoveryContext:
+    """Context for error recovery operations.
+
+    Tracks recovery attempts and provides utilities for recovery.
+
+    Attributes:
+        original_error: The error that triggered recovery.
+        agent_name: Name of the agent being recovered.
+        attempts: List of recovery attempts.
+        max_attempts: Maximum recovery attempts allowed.
+    """
+
+    original_error: Exception
+    agent_name: str | None = None
+    attempts: list[RecoveryAttempt] = field(default_factory=list)
+    max_attempts: int = 3
+
+    def add_attempt(self, strategy: str, success: bool, error: str | None = None) -> None:
+        """Record a recovery attempt."""
+        self.attempts.append(
+            RecoveryAttempt(strategy=strategy, success=success, error=error)
+        )
+
+    @property
+    def attempt_count(self) -> int:
+        """Number of recovery attempts made."""
+        return len(self.attempts)
+
+    @property
+    def can_retry(self) -> bool:
+        """Check if more recovery attempts are allowed."""
+        return self.attempt_count < self.max_attempts
+
+    @property
+    def last_attempt(self) -> RecoveryAttempt | None:
+        """Get the last recovery attempt."""
+        return self.attempts[-1] if self.attempts else None
+
+
+class ErrorRecoveryManager:
+    """Manager for error recovery operations.
+
+    Coordinates retry logic, fallback execution, and recovery tracking.
+
+    Example:
+        manager = ErrorRecoveryManager()
+
+        try:
+            result = await agent.execute(state)
+        except AgentError as e:
+            result = await manager.recover(
+                error=e,
+                agent_name="research_agent",
+                fallback_fn=lambda: cached_data,
+            )
+    """
+
+    def __init__(self) -> None:
+        """Initialize the recovery manager."""
+        self._active_recoveries: dict[str, RecoveryContext] = {}
+
+    async def recover(
+        self,
+        error: Exception,
+        agent_name: str,
+        fallback_fn: Callable[[], Awaitable[T] | T] | None = None,
+        state: dict[str, Any] | None = None,
+    ) -> T:
+        """Attempt to recover from an error.
+
+        Args:
+            error: The error to recover from.
+            agent_name: Name of the agent that failed.
+            fallback_fn: Function to generate fallback data.
+            state: Current workflow state for context.
+
+        Returns:
+            Recovery result (either retry success or fallback data).
+
+        Raises:
+            RecoveryError: If all recovery attempts fail.
+        """
+        config = get_agent_fallback_config(agent_name)
+        context = RecoveryContext(
+            original_error=error,
+            agent_name=agent_name,
+            max_attempts=config.max_retries,
+        )
+        self._active_recoveries[agent_name] = context
+
+        logger.warning(
+            "recovery_started",
+            agent_name=agent_name,
+            error_type=type(error).__name__,
+            error_message=str(error),
+        )
+
+        try:
+            # Check if error is recoverable
+            if isinstance(error, PortfolioAdvisorError) and not error.recoverable:
+                raise RecoveryError(
+                    f"Non-recoverable error in {agent_name}: {error}",
+                    original_error=error,
+                    recovery_attempts=0,
+                )
+
+            # Try fallback
+            if fallback_fn or config.fallback_fn:
+                fn = fallback_fn or config.fallback_fn
+                if fn is None:
+                    raise RecoveryError(
+                        f"No fallback function for {agent_name}",
+                        original_error=error,
+                    )
+                try:
+                    result = fn()
+                    if asyncio.iscoroutine(result):
+                        result = await result
+
+                    context.add_attempt("fallback", success=True)
+                    logger.info(
+                        "recovery_succeeded",
+                        agent_name=agent_name,
+                        strategy="fallback",
+                        warning=config.warning_message,
+                    )
+                    return result  # type: ignore[return-value]
+
+                except Exception as fallback_error:
+                    context.add_attempt(
+                        "fallback", success=False, error=str(fallback_error)
+                    )
+                    raise RecoveryError(
+                        f"Fallback failed for {agent_name}: {fallback_error}",
+                        original_error=error,
+                        recovery_attempts=context.attempt_count,
+                    ) from fallback_error
+
+            # No fallback available
+            raise RecoveryError(
+                f"No recovery strategy for {agent_name}",
+                original_error=error,
+                recovery_attempts=context.attempt_count,
+            )
+
+        finally:
+            del self._active_recoveries[agent_name]
+
+    def get_active_recovery(self, agent_name: str) -> RecoveryContext | None:
+        """Get active recovery context for an agent."""
+        return self._active_recoveries.get(agent_name)
+
+
+# Global recovery manager instance
+_recovery_manager: ErrorRecoveryManager | None = None
+
+
+def get_recovery_manager() -> ErrorRecoveryManager:
+    """Get the global recovery manager instance."""
+    global _recovery_manager
+    if _recovery_manager is None:
+        _recovery_manager = ErrorRecoveryManager()
+    return _recovery_manager
+
+
+def reset_recovery_manager() -> None:
+    """Reset the global recovery manager (for testing)."""
+    global _recovery_manager
+    _recovery_manager = None
+
+
+# ============================================================================
+# Utility Functions
+# ============================================================================
+
+
+async def execute_with_timeout(
+    coro: Awaitable[T],
+    timeout_seconds: float,
+    operation_name: str = "operation",
+) -> T:
+    """Execute a coroutine with a timeout.
+
+    Args:
+        coro: The coroutine to execute.
+        timeout_seconds: Maximum time to wait.
+        operation_name: Name of operation for error messages.
+
+    Returns:
+        The coroutine result.
+
+    Raises:
+        WorkflowTimeoutError: If the operation times out.
+    """
+    try:
+        return await asyncio.wait_for(coro, timeout=timeout_seconds)
+    except asyncio.TimeoutError as e:
+        raise WorkflowTimeoutError(
+            f"{operation_name} timed out after {timeout_seconds}s",
+            timeout_seconds=timeout_seconds,
+            operation=operation_name,
+        ) from e
+
+
+def classify_error(error: Exception) -> tuple[str, bool]:
+    """Classify an error for handling.
+
+    Args:
+        error: The error to classify.
+
+    Returns:
+        Tuple of (error_category, is_recoverable).
+    """
+    if isinstance(error, PortfolioAdvisorError):
+        return (type(error).__name__, error.recoverable)
+
+    # Map common exceptions to categories
+    error_map: dict[type[Exception], tuple[str, bool]] = {
+        TimeoutError: ("timeout", True),
+        asyncio.TimeoutError: ("timeout", True),
+        ConnectionError: ("connection", True),
+        ValueError: ("validation", False),
+        KeyError: ("state", False),
+    }
+
+    for exc_type, (category, recoverable) in error_map.items():
+        if isinstance(error, exc_type):
+            return (category, recoverable)
+
+    return ("unknown", False)
+
+
+def is_critical_error(error: Exception) -> bool:
+    """Check if an error is critical (should stop the workflow).
+
+    Args:
+        error: The error to check.
+
+    Returns:
+        True if the error is critical.
+    """
+    # Check for non-recoverable Portfolio errors
+    if isinstance(error, PortfolioAdvisorError):
+        return not error.recoverable
+
+    # Check for state errors
+    if isinstance(error, (StateError, RecoveryError)):
+        return True
+
+    # Check error message for critical indicators
+    error_str = str(error).lower()
+    critical_keywords = ["critical", "fatal", "unrecoverable", "authentication"]
+    return any(keyword in error_str for keyword in critical_keywords)

--- a/tests/test_orchestration/test_errors.py
+++ b/tests/test_orchestration/test_errors.py
@@ -1,0 +1,591 @@
+"""Tests for error handling and recovery module."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.orchestration.errors import (
+    AGENT_FALLBACK_CONFIGS,
+    AgentError,
+    AgentFallbackConfig,
+    ErrorRecoveryManager,
+    FallbackType,
+    PortfolioAdvisorError,
+    RecoveryContext,
+    RecoveryError,
+    RetryConfig,
+    RetryStrategy,
+    StateError,
+    ToolError,
+    WorkflowTimeoutError,
+    classify_error,
+    execute_with_timeout,
+    get_agent_fallback_config,
+    get_recovery_manager,
+    is_critical_error,
+    reset_recovery_manager,
+    with_retry,
+)
+
+
+# ============================================================================
+# Exception Hierarchy Tests
+# ============================================================================
+
+
+class TestPortfolioAdvisorError:
+    """Tests for base PortfolioAdvisorError."""
+
+    def test_basic_creation(self) -> None:
+        """Test basic error creation."""
+        error = PortfolioAdvisorError("Test error")
+        assert str(error) == "Test error"
+        assert error.message == "Test error"
+        assert error.recoverable is True
+        assert error.details == {}
+        assert error.trace_id is None
+
+    def test_with_all_attributes(self) -> None:
+        """Test error with all attributes."""
+        error = PortfolioAdvisorError(
+            "Test error",
+            details={"key": "value"},
+            recoverable=False,
+            trace_id="trace-123",
+        )
+        assert error.details == {"key": "value"}
+        assert error.recoverable is False
+        assert error.trace_id == "trace-123"
+
+    def test_to_dict(self) -> None:
+        """Test conversion to dictionary."""
+        error = PortfolioAdvisorError(
+            "Test error",
+            details={"key": "value"},
+            trace_id="trace-123",
+        )
+        result = error.to_dict()
+        assert result["error_type"] == "PortfolioAdvisorError"
+        assert result["message"] == "Test error"
+        assert result["details"] == {"key": "value"}
+        assert result["trace_id"] == "trace-123"
+
+
+class TestAgentError:
+    """Tests for AgentError."""
+
+    def test_creation_with_agent_name(self) -> None:
+        """Test error with agent name."""
+        error = AgentError(
+            "Research failed",
+            agent_name="research_agent",
+            stage="data_fetch",
+        )
+        assert error.agent_name == "research_agent"
+        assert error.stage == "data_fetch"
+
+    def test_to_dict_includes_agent_info(self) -> None:
+        """Test to_dict includes agent information."""
+        error = AgentError(
+            "Analysis failed",
+            agent_name="analysis_agent",
+            stage="risk_calculation",
+        )
+        result = error.to_dict()
+        assert result["agent_name"] == "analysis_agent"
+        assert result["stage"] == "risk_calculation"
+        assert result["error_type"] == "AgentError"
+
+
+class TestToolError:
+    """Tests for ToolError."""
+
+    def test_creation_with_tool_name(self) -> None:
+        """Test error with tool name."""
+        error = ToolError(
+            "API call failed",
+            tool_name="market_data",
+            input_data={"symbol": "AAPL"},
+        )
+        assert error.tool_name == "market_data"
+        assert error.input_data == {"symbol": "AAPL"}
+
+    def test_to_dict_includes_tool_info(self) -> None:
+        """Test to_dict includes tool information."""
+        error = ToolError(
+            "News fetch failed",
+            tool_name="news_search",
+        )
+        result = error.to_dict()
+        assert result["tool_name"] == "news_search"
+        assert result["error_type"] == "ToolError"
+
+
+class TestStateError:
+    """Tests for StateError."""
+
+    def test_creation_with_state_info(self) -> None:
+        """Test error with state information."""
+        error = StateError(
+            "Invalid state",
+            state_key="research",
+            expected="dict",
+            actual="None",
+        )
+        assert error.state_key == "research"
+        assert error.expected == "dict"
+        assert error.actual == "None"
+        assert error.recoverable is False  # State errors are not recoverable by default
+
+    def test_to_dict_includes_state_info(self) -> None:
+        """Test to_dict includes state information."""
+        error = StateError(
+            "Missing key",
+            state_key="analysis",
+        )
+        result = error.to_dict()
+        assert result["state_key"] == "analysis"
+        assert result["error_type"] == "StateError"
+
+
+class TestWorkflowTimeoutError:
+    """Tests for WorkflowTimeoutError."""
+
+    def test_creation_with_timeout_info(self) -> None:
+        """Test error with timeout information."""
+        error = WorkflowTimeoutError(
+            "Operation timed out",
+            timeout_seconds=30.0,
+            operation="market_data_fetch",
+        )
+        assert error.timeout_seconds == 30.0
+        assert error.operation == "market_data_fetch"
+
+    def test_to_dict_includes_timeout_info(self) -> None:
+        """Test to_dict includes timeout information."""
+        error = WorkflowTimeoutError(
+            "Timeout",
+            timeout_seconds=60.0,
+            operation="analysis",
+        )
+        result = error.to_dict()
+        assert result["timeout_seconds"] == 60.0
+        assert result["operation"] == "analysis"
+
+
+class TestRecoveryError:
+    """Tests for RecoveryError."""
+
+    def test_creation_with_original_error(self) -> None:
+        """Test error with original error."""
+        original = AgentError("Original", agent_name="test")
+        error = RecoveryError(
+            "Recovery failed",
+            original_error=original,
+            recovery_attempts=3,
+        )
+        assert error.original_error is original
+        assert error.recovery_attempts == 3
+        assert error.recoverable is False  # Recovery errors are never recoverable
+
+    def test_to_dict_includes_recovery_info(self) -> None:
+        """Test to_dict includes recovery information."""
+        error = RecoveryError(
+            "All retries exhausted",
+            recovery_attempts=5,
+        )
+        result = error.to_dict()
+        assert result["recovery_attempts"] == 5
+        assert result["error_type"] == "RecoveryError"
+
+
+# ============================================================================
+# Retry Configuration Tests
+# ============================================================================
+
+
+class TestRetryConfig:
+    """Tests for RetryConfig."""
+
+    def test_default_config(self) -> None:
+        """Test default retry configuration."""
+        config = RetryConfig()
+        assert config.max_attempts == 3
+        assert config.min_wait_seconds == 1.0
+        assert config.max_wait_seconds == 30.0
+        assert config.multiplier == 2.0
+
+    def test_from_strategy_none(self) -> None:
+        """Test creating config from NONE strategy."""
+        config = RetryConfig.from_strategy(RetryStrategy.NONE)
+        assert config.max_attempts == 1
+
+    def test_from_strategy_quick(self) -> None:
+        """Test creating config from QUICK strategy."""
+        config = RetryConfig.from_strategy(RetryStrategy.QUICK)
+        assert config.max_attempts == 2
+        assert config.min_wait_seconds == 0.5
+        assert config.max_wait_seconds == 5.0
+
+    def test_from_strategy_standard(self) -> None:
+        """Test creating config from STANDARD strategy."""
+        config = RetryConfig.from_strategy(RetryStrategy.STANDARD)
+        assert config.max_attempts == 3
+
+    def test_from_strategy_persistent(self) -> None:
+        """Test creating config from PERSISTENT strategy."""
+        config = RetryConfig.from_strategy(RetryStrategy.PERSISTENT)
+        assert config.max_attempts == 5
+        assert config.max_wait_seconds == 60.0
+
+
+class TestWithRetryDecorator:
+    """Tests for with_retry decorator."""
+
+    @pytest.mark.asyncio
+    async def test_successful_call_no_retry(self) -> None:
+        """Test successful call doesn't retry."""
+        call_count = 0
+
+        @with_retry(RetryConfig(max_attempts=3))
+        async def successful_fn() -> str:
+            nonlocal call_count
+            call_count += 1
+            return "success"
+
+        result = await successful_fn()
+        assert result == "success"
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_on_agent_error(self) -> None:
+        """Test retries on AgentError."""
+        call_count = 0
+
+        @with_retry(RetryConfig(max_attempts=3, min_wait_seconds=0.01, max_wait_seconds=0.1))
+        async def failing_fn() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise AgentError("Retry me", agent_name="test")
+            return "success"
+
+        result = await failing_fn()
+        assert result == "success"
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_exhausts_retries(self) -> None:
+        """Test exhausts all retries and raises."""
+        call_count = 0
+
+        @with_retry(RetryConfig(max_attempts=2, min_wait_seconds=0.01, max_wait_seconds=0.1))
+        async def always_failing() -> str:
+            nonlocal call_count
+            call_count += 1
+            raise AgentError("Always fails", agent_name="test")
+
+        with pytest.raises(AgentError):
+            await always_failing()
+
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_with_retry_strategy(self) -> None:
+        """Test with RetryStrategy enum."""
+        call_count = 0
+
+        @with_retry(RetryStrategy.QUICK)
+        async def fn() -> str:
+            nonlocal call_count
+            call_count += 1
+            return "done"
+
+        result = await fn()
+        assert result == "done"
+        assert call_count == 1
+
+
+# ============================================================================
+# Fallback Configuration Tests
+# ============================================================================
+
+
+class TestAgentFallbackConfig:
+    """Tests for AgentFallbackConfig."""
+
+    def test_default_configs_exist(self) -> None:
+        """Test default configs exist for known agents."""
+        assert "research_agent" in AGENT_FALLBACK_CONFIGS
+        assert "analysis_agent" in AGENT_FALLBACK_CONFIGS
+        assert "recommendation_agent" in AGENT_FALLBACK_CONFIGS
+
+    def test_get_agent_fallback_config_known(self) -> None:
+        """Test getting config for known agent."""
+        config = get_agent_fallback_config("research_agent")
+        assert config.agent_name == "research_agent"
+        assert config.fallback_type == FallbackType.CACHED_DATA
+
+    def test_get_agent_fallback_config_unknown(self) -> None:
+        """Test getting config for unknown agent returns default."""
+        config = get_agent_fallback_config("unknown_agent")
+        assert config.agent_name == "unknown_agent"
+        assert config.fallback_type == FallbackType.ERROR
+
+
+# ============================================================================
+# Recovery Context Tests
+# ============================================================================
+
+
+class TestRecoveryContext:
+    """Tests for RecoveryContext."""
+
+    def test_creation(self) -> None:
+        """Test context creation."""
+        error = AgentError("Test", agent_name="test")
+        context = RecoveryContext(original_error=error, agent_name="test_agent")
+        assert context.original_error is error
+        assert context.agent_name == "test_agent"
+        assert context.attempt_count == 0
+        assert context.can_retry is True
+
+    def test_add_attempt(self) -> None:
+        """Test adding recovery attempts."""
+        error = AgentError("Test", agent_name="test")
+        context = RecoveryContext(original_error=error, max_attempts=2)
+
+        context.add_attempt("retry", success=False, error="Failed")
+        assert context.attempt_count == 1
+        assert context.can_retry is True
+
+        context.add_attempt("fallback", success=True)
+        assert context.attempt_count == 2
+        assert context.can_retry is False
+
+    def test_last_attempt(self) -> None:
+        """Test getting last attempt."""
+        error = AgentError("Test", agent_name="test")
+        context = RecoveryContext(original_error=error)
+
+        assert context.last_attempt is None
+
+        context.add_attempt("retry", success=False)
+        assert context.last_attempt is not None
+        assert context.last_attempt.strategy == "retry"
+
+
+# ============================================================================
+# Error Recovery Manager Tests
+# ============================================================================
+
+
+class TestErrorRecoveryManager:
+    """Tests for ErrorRecoveryManager."""
+
+    def test_creation(self) -> None:
+        """Test manager creation."""
+        manager = ErrorRecoveryManager()
+        assert manager is not None
+
+    @pytest.mark.asyncio
+    async def test_recover_with_fallback_fn(self) -> None:
+        """Test recovery with fallback function."""
+        manager = ErrorRecoveryManager()
+        error = AgentError("Failed", agent_name="research_agent")
+
+        result = await manager.recover(
+            error=error,
+            agent_name="research_agent",
+            fallback_fn=lambda: {"cached": True},
+        )
+
+        assert result == {"cached": True}
+
+    @pytest.mark.asyncio
+    async def test_recover_with_async_fallback(self) -> None:
+        """Test recovery with async fallback function."""
+        manager = ErrorRecoveryManager()
+        error = AgentError("Failed", agent_name="research_agent")
+
+        async def async_fallback() -> dict:
+            return {"async_cached": True}
+
+        result = await manager.recover(
+            error=error,
+            agent_name="research_agent",
+            fallback_fn=async_fallback,
+        )
+
+        assert result == {"async_cached": True}
+
+    @pytest.mark.asyncio
+    async def test_recover_non_recoverable_error(self) -> None:
+        """Test recovery fails for non-recoverable error."""
+        manager = ErrorRecoveryManager()
+        error = StateError("State error", recoverable=False)
+
+        with pytest.raises(RecoveryError) as exc_info:
+            await manager.recover(
+                error=error,
+                agent_name="test_agent",
+                fallback_fn=lambda: "fallback",
+            )
+
+        assert "Non-recoverable" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_recover_fallback_fails(self) -> None:
+        """Test when fallback itself fails."""
+        manager = ErrorRecoveryManager()
+        error = AgentError("Failed", agent_name="test")
+
+        def failing_fallback() -> None:
+            raise ValueError("Fallback failed")
+
+        with pytest.raises(RecoveryError) as exc_info:
+            await manager.recover(
+                error=error,
+                agent_name="test",
+                fallback_fn=failing_fallback,
+            )
+
+        assert "Fallback failed" in str(exc_info.value)
+
+
+class TestGlobalRecoveryManager:
+    """Tests for global recovery manager functions."""
+
+    def setup_method(self) -> None:
+        """Reset global manager before each test."""
+        reset_recovery_manager()
+
+    def test_get_recovery_manager_creates_instance(self) -> None:
+        """Test get creates instance if none exists."""
+        manager = get_recovery_manager()
+        assert manager is not None
+        assert isinstance(manager, ErrorRecoveryManager)
+
+    def test_get_recovery_manager_returns_same_instance(self) -> None:
+        """Test get returns same instance."""
+        manager1 = get_recovery_manager()
+        manager2 = get_recovery_manager()
+        assert manager1 is manager2
+
+    def test_reset_recovery_manager(self) -> None:
+        """Test reset clears the manager."""
+        manager1 = get_recovery_manager()
+        reset_recovery_manager()
+        manager2 = get_recovery_manager()
+        assert manager1 is not manager2
+
+
+# ============================================================================
+# Utility Function Tests
+# ============================================================================
+
+
+class TestExecuteWithTimeout:
+    """Tests for execute_with_timeout."""
+
+    @pytest.mark.asyncio
+    async def test_completes_within_timeout(self) -> None:
+        """Test successful completion within timeout."""
+
+        async def quick_fn() -> str:
+            return "done"
+
+        result = await execute_with_timeout(quick_fn(), timeout_seconds=1.0)
+        assert result == "done"
+
+    @pytest.mark.asyncio
+    async def test_raises_on_timeout(self) -> None:
+        """Test raises WorkflowTimeoutError on timeout."""
+
+        async def slow_fn() -> str:
+            await asyncio.sleep(10)
+            return "never"
+
+        with pytest.raises(WorkflowTimeoutError) as exc_info:
+            await execute_with_timeout(
+                slow_fn(),
+                timeout_seconds=0.01,
+                operation_name="slow_operation",
+            )
+
+        assert exc_info.value.timeout_seconds == 0.01
+        assert exc_info.value.operation == "slow_operation"
+
+
+class TestClassifyError:
+    """Tests for classify_error."""
+
+    def test_classify_agent_error(self) -> None:
+        """Test classifying AgentError."""
+        error = AgentError("Test", agent_name="test")
+        category, recoverable = classify_error(error)
+        assert category == "AgentError"
+        assert recoverable is True
+
+    def test_classify_state_error(self) -> None:
+        """Test classifying StateError."""
+        error = StateError("Test")
+        category, recoverable = classify_error(error)
+        assert category == "StateError"
+        assert recoverable is False
+
+    def test_classify_timeout_error(self) -> None:
+        """Test classifying TimeoutError."""
+        error = TimeoutError("Timeout")
+        category, recoverable = classify_error(error)
+        assert category == "timeout"
+        assert recoverable is True
+
+    def test_classify_connection_error(self) -> None:
+        """Test classifying ConnectionError."""
+        error = ConnectionError("Connection refused")
+        category, recoverable = classify_error(error)
+        assert category == "connection"
+        assert recoverable is True
+
+    def test_classify_unknown_error(self) -> None:
+        """Test classifying unknown error."""
+        error = RuntimeError("Unknown")
+        category, recoverable = classify_error(error)
+        assert category == "unknown"
+        assert recoverable is False
+
+
+class TestIsCriticalError:
+    """Tests for is_critical_error."""
+
+    def test_non_recoverable_is_critical(self) -> None:
+        """Test non-recoverable errors are critical."""
+        error = PortfolioAdvisorError("Error", recoverable=False)
+        assert is_critical_error(error) is True
+
+    def test_recoverable_is_not_critical(self) -> None:
+        """Test recoverable errors are not critical."""
+        error = AgentError("Error", agent_name="test", recoverable=True)
+        assert is_critical_error(error) is False
+
+    def test_state_error_is_critical(self) -> None:
+        """Test StateError is always critical."""
+        error = StateError("Error")
+        assert is_critical_error(error) is True
+
+    def test_recovery_error_is_critical(self) -> None:
+        """Test RecoveryError is always critical."""
+        error = RecoveryError("Error")
+        assert is_critical_error(error) is True
+
+    def test_critical_keyword_in_message(self) -> None:
+        """Test error with 'critical' in message."""
+        error = RuntimeError("CRITICAL: System failure")
+        assert is_critical_error(error) is True
+
+    def test_fatal_keyword_in_message(self) -> None:
+        """Test error with 'fatal' in message."""
+        error = RuntimeError("Fatal error occurred")
+        assert is_critical_error(error) is True


### PR DESCRIPTION
## Summary

- Implements comprehensive error handling for multi-agent workflows
- Adds custom exception hierarchy with recoverable/non-recoverable errors
- Implements retry logic with exponential backoff using tenacity
- Adds per-agent fallback strategies with configurable behaviors
- Creates recovery manager for coordinated error recovery

## Changes

### New Module: `src/orchestration/errors.py`

**Exception Hierarchy:**
- `PortfolioAdvisorError`: Base exception with recoverable flag and trace_id
- `AgentError`: Agent failures with agent_name and stage
- `ToolError`: Tool failures with tool_name and input_data
- `StateError`: State validation failures (non-recoverable by default)
- `WorkflowTimeoutError`: Operation timeouts with timeout_seconds
- `RecoveryError`: Failed recovery attempts with original error

**Retry System:**
- `RetryConfig`: Configurable attempts, wait times, and exception types
- `RetryStrategy` presets: NONE, QUICK, STANDARD, PERSISTENT
- `@with_retry` decorator with exponential backoff

**Fallback Strategies:**
- `FallbackType`: CACHED_DATA, MOCK_DATA, PARTIAL_RESULT, SKIP, ERROR
- `AgentFallbackConfig`: Per-agent configuration with warning messages
- Default configs for research, analysis, and recommendation agents

**Recovery Management:**
- `ErrorRecoveryManager`: Coordinated recovery with fallback execution
- `RecoveryContext`: Track recovery attempts and state
- Global recovery manager with `get_recovery_manager()`

**Utilities:**
- `execute_with_timeout()`: Async operation with timeout
- `classify_error()`: Error categorization
- `is_critical_error()`: Check if error should stop workflow

### Updated: `src/orchestration/__init__.py`
- Exports all new error handling classes and functions

## Test Plan

- [x] 49 new tests for error handling module
- [x] All 860 tests pass
- [x] Exception hierarchy works correctly
- [x] Retry decorator retries on recoverable errors
- [x] Recovery manager executes fallbacks successfully

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)