### PR TITLE
feat: Add human-in-the-loop approval workflow (#75)

### DIFF
--- a/src/api/approvals.py
+++ b/src/api/approvals.py
@@ -1,0 +1,419 @@
+"""API routes for human approval workflows.
+
+This module provides endpoints for managing approval requests:
+- List pending approvals
+- Get approval details
+- Approve/reject/modify recommendations
+"""
+
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from src.approval import (
+    ApprovalRequest,
+    ApprovalStatus,
+    get_approval_manager,
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/approvals", tags=["Approvals"])
+
+
+# ============================================================================
+# Request/Response Models
+# ============================================================================
+
+
+class ApproveRequest(BaseModel):
+    """Request to approve a recommendation."""
+
+    reviewer_id: str = Field(..., description="ID of the reviewer approving")
+    reason: str | None = Field(
+        default=None, description="Optional reason for approval"
+    )
+
+
+class RejectRequest(BaseModel):
+    """Request to reject a recommendation."""
+
+    reviewer_id: str = Field(..., description="ID of the reviewer rejecting")
+    reason: str = Field(..., description="Reason for rejection")
+
+
+class ModifyRequest(BaseModel):
+    """Request to approve with modifications."""
+
+    reviewer_id: str = Field(..., description="ID of the reviewer")
+    modified_trades: list[dict[str, Any]] = Field(
+        ..., description="Modified trade list"
+    )
+    reason: str | None = Field(
+        default=None, description="Reason for modification"
+    )
+
+
+class ApprovalSummary(BaseModel):
+    """Summary of an approval request for listing."""
+
+    approval_id: str
+    workflow_id: str
+    trace_id: str
+    status: str
+    risk_level: str
+    total_value: float
+    trade_count: int
+    created_at: str
+    expires_at: str | None
+    summary: str
+
+
+class ApprovalDetail(BaseModel):
+    """Full detail of an approval request."""
+
+    approval_id: str
+    workflow_id: str
+    trace_id: str
+    user_id: str | None
+    status: str
+    risk_level: str
+    triggers: list[str]
+    trades: list[dict[str, Any]]
+    total_value: float
+    portfolio_value: float
+    compliance: dict[str, Any]
+    summary: str
+    analysis_context: dict[str, Any]
+    created_at: str
+    expires_at: str | None
+    decision: dict[str, Any] | None
+
+
+class ApprovalResponse(BaseModel):
+    """Response after an approval action."""
+
+    approval_id: str
+    status: str
+    message: str
+
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+
+def _approval_to_summary(approval: ApprovalRequest) -> ApprovalSummary:
+    """Convert an approval request to a summary."""
+    return ApprovalSummary(
+        approval_id=approval.approval_id,
+        workflow_id=approval.workflow_id,
+        trace_id=approval.trace_id,
+        status=approval.status.value,
+        risk_level=approval.risk_level.value,
+        total_value=approval.total_value,
+        trade_count=len(approval.trades),
+        created_at=approval.created_at.isoformat(),
+        expires_at=approval.expires_at.isoformat() if approval.expires_at else None,
+        summary=approval.summary,
+    )
+
+
+def _approval_to_detail(approval: ApprovalRequest) -> ApprovalDetail:
+    """Convert an approval request to full detail."""
+    return ApprovalDetail(
+        approval_id=approval.approval_id,
+        workflow_id=approval.workflow_id,
+        trace_id=approval.trace_id,
+        user_id=approval.user_id,
+        status=approval.status.value,
+        risk_level=approval.risk_level.value,
+        triggers=[t.value for t in approval.triggers],
+        trades=approval.trades,
+        total_value=approval.total_value,
+        portfolio_value=approval.portfolio_value,
+        compliance=approval.compliance,
+        summary=approval.summary,
+        analysis_context=approval.analysis_context,
+        created_at=approval.created_at.isoformat(),
+        expires_at=approval.expires_at.isoformat() if approval.expires_at else None,
+        decision=approval.decision.model_dump(mode="json")
+        if approval.decision
+        else None,
+    )
+
+
+# ============================================================================
+# Routes
+# ============================================================================
+
+
+@router.get(
+    "",
+    response_model=list[ApprovalSummary],
+    summary="List pending approvals",
+    description="Get a list of pending approval requests.",
+)
+async def list_approvals(
+    user_id: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[ApprovalSummary]:
+    """List pending approval requests.
+
+    Args:
+        user_id: Optional filter by user ID.
+        limit: Maximum number of results (default 50).
+        offset: Pagination offset.
+
+    Returns:
+        List of pending approval summaries.
+    """
+    manager = get_approval_manager()
+    approvals = await manager.list_pending(
+        user_id=user_id, limit=limit, offset=offset
+    )
+
+    logger.info(
+        "approvals_listed",
+        count=len(approvals),
+        user_id=user_id,
+    )
+
+    return [_approval_to_summary(a) for a in approvals]
+
+
+@router.get(
+    "/{approval_id}",
+    response_model=ApprovalDetail,
+    summary="Get approval details",
+    description="Get full details of an approval request.",
+    responses={
+        404: {"description": "Approval not found"},
+    },
+)
+async def get_approval(approval_id: str) -> ApprovalDetail:
+    """Get approval request details.
+
+    Args:
+        approval_id: The approval request ID.
+
+    Returns:
+        Full approval request details.
+
+    Raises:
+        HTTPException: If approval not found.
+    """
+    manager = get_approval_manager()
+    approval = await manager.get_approval(approval_id)
+
+    if approval is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Approval request '{approval_id}' not found",
+        )
+
+    logger.info(
+        "approval_retrieved",
+        approval_id=approval_id,
+        status=approval.status.value,
+    )
+
+    return _approval_to_detail(approval)
+
+
+@router.post(
+    "/{approval_id}/approve",
+    response_model=ApprovalResponse,
+    summary="Approve a recommendation",
+    description="Approve a pending recommendation for execution.",
+    responses={
+        404: {"description": "Approval not found"},
+        400: {"description": "Approval is not in pending status"},
+    },
+)
+async def approve_recommendation(
+    approval_id: str,
+    request: ApproveRequest,
+) -> ApprovalResponse:
+    """Approve a pending recommendation.
+
+    Args:
+        approval_id: The approval request ID.
+        request: Approval request with reviewer info.
+
+    Returns:
+        Response confirming the approval.
+
+    Raises:
+        HTTPException: If approval not found or not pending.
+    """
+    manager = get_approval_manager()
+
+    # Check current state before attempting approval
+    current_approval = await manager.get_approval(approval_id)
+    if current_approval is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Approval request '{approval_id}' not found",
+        )
+
+    if not current_approval.is_pending():
+        if current_approval.status == ApprovalStatus.EXPIRED:
+            raise HTTPException(
+                status_code=400,
+                detail="Approval request has expired",
+            )
+        raise HTTPException(
+            status_code=400,
+            detail=f"Approval is not in pending status (current: {current_approval.status.value})",
+        )
+
+    approval = await manager.approve(
+        approval_id=approval_id,
+        reviewer_id=request.reviewer_id,
+        reason=request.reason,
+    )
+
+    if approval is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Approval request '{approval_id}' not found",
+        )
+
+    if approval.status == ApprovalStatus.EXPIRED:
+        raise HTTPException(
+            status_code=400,
+            detail="Approval request has expired",
+        )
+
+    if approval.status != ApprovalStatus.APPROVED:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Failed to approve (current: {approval.status.value})",
+        )
+
+    return ApprovalResponse(
+        approval_id=approval.approval_id,
+        status=approval.status.value,
+        message="Recommendation approved successfully",
+    )
+
+
+@router.post(
+    "/{approval_id}/reject",
+    response_model=ApprovalResponse,
+    summary="Reject a recommendation",
+    description="Reject a pending recommendation with a reason.",
+    responses={
+        404: {"description": "Approval not found"},
+        400: {"description": "Approval is not in pending status"},
+    },
+)
+async def reject_recommendation(
+    approval_id: str,
+    request: RejectRequest,
+) -> ApprovalResponse:
+    """Reject a pending recommendation.
+
+    Args:
+        approval_id: The approval request ID.
+        request: Rejection request with reviewer info and reason.
+
+    Returns:
+        Response confirming the rejection.
+
+    Raises:
+        HTTPException: If approval not found or not pending.
+    """
+    manager = get_approval_manager()
+    approval = await manager.reject(
+        approval_id=approval_id,
+        reviewer_id=request.reviewer_id,
+        reason=request.reason,
+    )
+
+    if approval is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Approval request '{approval_id}' not found",
+        )
+
+    if approval.status == ApprovalStatus.EXPIRED:
+        raise HTTPException(
+            status_code=400,
+            detail="Approval request has expired",
+        )
+
+    if approval.status != ApprovalStatus.REJECTED:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Approval is not in pending status (current: {approval.status.value})",
+        )
+
+    return ApprovalResponse(
+        approval_id=approval.approval_id,
+        status=approval.status.value,
+        message="Recommendation rejected",
+    )
+
+
+@router.post(
+    "/{approval_id}/modify",
+    response_model=ApprovalResponse,
+    summary="Approve with modifications",
+    description="Approve a recommendation with modified trades.",
+    responses={
+        404: {"description": "Approval not found"},
+        400: {"description": "Approval is not in pending status"},
+    },
+)
+async def modify_recommendation(
+    approval_id: str,
+    request: ModifyRequest,
+) -> ApprovalResponse:
+    """Approve a recommendation with modifications.
+
+    Args:
+        approval_id: The approval request ID.
+        request: Modification request with new trades.
+
+    Returns:
+        Response confirming the modification.
+
+    Raises:
+        HTTPException: If approval not found or not pending.
+    """
+    manager = get_approval_manager()
+    approval = await manager.modify(
+        approval_id=approval_id,
+        reviewer_id=request.reviewer_id,
+        modified_trades=request.modified_trades,
+        reason=request.reason,
+    )
+
+    if approval is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Approval request '{approval_id}' not found",
+        )
+
+    if approval.status == ApprovalStatus.EXPIRED:
+        raise HTTPException(
+            status_code=400,
+            detail="Approval request has expired",
+        )
+
+    if approval.status != ApprovalStatus.MODIFIED:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Approval is not in pending status (current: {approval.status.value})",
+        )
+
+    return ApprovalResponse(
+        approval_id=approval.approval_id,
+        status=approval.status.value,
+        message="Recommendation approved with modifications",
+    )

--- a/src/approval/__init__.py
+++ b/src/approval/__init__.py
@@ -1,0 +1,24 @@
+"""Human-in-the-loop approval workflow module.
+
+This module provides approval workflows for high-risk recommendations,
+enabling human oversight before trade execution.
+"""
+
+from src.approval.manager import ApprovalManager, get_approval_manager
+from src.approval.models import (
+    ApprovalDecision,
+    ApprovalRequest,
+    ApprovalStatus,
+    ApprovalTrigger,
+    RiskLevel,
+)
+
+__all__ = [
+    "ApprovalDecision",
+    "ApprovalManager",
+    "ApprovalRequest",
+    "ApprovalStatus",
+    "ApprovalTrigger",
+    "RiskLevel",
+    "get_approval_manager",
+]

--- a/src/approval/manager.py
+++ b/src/approval/manager.py
@@ -1,0 +1,922 @@
+"""Approval Manager for orchestrating human approval workflows.
+
+This module provides the core logic for evaluating recommendations,
+creating approval requests, and managing the approval lifecycle.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+from pydantic import BaseModel
+
+from src.approval.models import (
+    ApprovalConfig,
+    ApprovalRequest,
+    ApprovalStatus,
+    ApprovalTrigger,
+    RiskLevel,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+# Global singleton for the approval manager
+_approval_manager: "ApprovalManager | None" = None
+
+
+def get_approval_manager() -> "ApprovalManager":
+    """Get the global approval manager instance.
+
+    Returns:
+        The singleton ApprovalManager instance.
+    """
+    global _approval_manager
+    if _approval_manager is None:
+        _approval_manager = ApprovalManager()
+    return _approval_manager
+
+
+def set_approval_manager(manager: "ApprovalManager") -> None:
+    """Set the global approval manager instance.
+
+    Args:
+        manager: The ApprovalManager instance to use.
+    """
+    global _approval_manager
+    _approval_manager = manager
+
+
+class ApprovalEvaluation(BaseModel):
+    """Result of evaluating whether approval is required."""
+
+    requires_approval: bool
+    risk_level: RiskLevel
+    triggers: list[ApprovalTrigger]
+    details: dict[str, Any]
+
+
+class ApprovalManager:
+    """Manages human approval workflows for high-risk recommendations.
+
+    The ApprovalManager is responsible for:
+    - Evaluating whether recommendations require approval
+    - Creating and storing approval requests
+    - Processing approval decisions
+    - Handling timeouts for stale requests
+    """
+
+    def __init__(
+        self,
+        config: ApprovalConfig | None = None,
+        persistence: "ApprovalPersistence | None" = None,
+    ) -> None:
+        """Initialize the ApprovalManager.
+
+        Args:
+            config: Approval configuration (uses defaults if not provided).
+            persistence: Persistence handler for storing approvals.
+        """
+        self.config = config or ApprovalConfig()
+        self.persistence = persistence or InMemoryApprovalPersistence()
+        logger.info(
+            "approval_manager_initialized",
+            config={
+                "high_value_threshold": self.config.high_value_threshold,
+                "concentration_threshold": self.config.concentration_threshold,
+                "auto_approve_low_risk": self.config.auto_approve_low_risk,
+            },
+        )
+
+    def evaluate_recommendation(
+        self,
+        trades: list[dict[str, Any]],
+        portfolio_value: float,
+        compliance: dict[str, Any],
+        analysis_context: dict[str, Any] | None = None,
+        known_symbols: set[str] | None = None,
+        confidence_score: float | None = None,
+    ) -> ApprovalEvaluation:
+        """Evaluate whether a recommendation requires human approval.
+
+        Args:
+            trades: List of proposed trades.
+            portfolio_value: Total portfolio value.
+            compliance: Compliance check results.
+            analysis_context: Additional context from analysis.
+            known_symbols: Set of previously traded symbols.
+            confidence_score: Model confidence score (0-1).
+
+        Returns:
+            ApprovalEvaluation with the determination.
+        """
+        triggers: list[ApprovalTrigger] = []
+        details: dict[str, Any] = {}
+        analysis_context = analysis_context or {}
+        known_symbols = known_symbols or set()
+
+        # Calculate total trade value
+        total_value = sum(
+            abs(t.get("estimated_value", 0)) for t in trades
+        )
+        details["total_trade_value"] = total_value
+
+        # Check high value threshold
+        if total_value > self.config.high_value_threshold:
+            triggers.append(ApprovalTrigger.HIGH_VALUE_TRADE)
+            details["value_threshold_exceeded"] = {
+                "threshold": self.config.high_value_threshold,
+                "actual": total_value,
+            }
+
+        # Check portfolio concentration
+        max_concentration = self._calculate_max_concentration(trades, portfolio_value)
+        details["max_concentration"] = max_concentration
+        if max_concentration > self.config.concentration_threshold:
+            triggers.append(ApprovalTrigger.HIGH_CONCENTRATION)
+            details["concentration_threshold_exceeded"] = {
+                "threshold": self.config.concentration_threshold,
+                "actual": max_concentration,
+            }
+
+        # Check for high-risk asset types
+        high_risk_symbols = self._find_high_risk_assets(trades)
+        if high_risk_symbols:
+            triggers.append(ApprovalTrigger.HIGH_RISK_ASSET)
+            details["high_risk_assets"] = high_risk_symbols
+
+        # Check for first-time symbols
+        new_symbols = self._find_new_symbols(trades, known_symbols)
+        if new_symbols:
+            triggers.append(ApprovalTrigger.FIRST_TIME_SYMBOL)
+            details["new_symbols"] = new_symbols
+
+        # Check confidence score
+        if confidence_score is not None and confidence_score < self.config.low_confidence_threshold:
+            triggers.append(ApprovalTrigger.LOW_CONFIDENCE)
+            details["confidence"] = {
+                "threshold": self.config.low_confidence_threshold,
+                "actual": confidence_score,
+            }
+
+        # Check compliance warnings
+        compliance_warnings = compliance.get("warnings", [])
+        compliance_violations = compliance.get("violations", [])
+        if compliance_warnings or compliance_violations:
+            triggers.append(ApprovalTrigger.COMPLIANCE_WARNING)
+            details["compliance_issues"] = {
+                "warnings": compliance_warnings,
+                "violations": compliance_violations,
+            }
+
+        # Check if compliance explicitly requires approval
+        if (
+            compliance.get("requires_approval", False)
+            and ApprovalTrigger.COMPLIANCE_WARNING not in triggers
+        ):
+            triggers.append(ApprovalTrigger.COMPLIANCE_WARNING)
+
+        # Determine risk level based on triggers and values
+        risk_level = self._determine_risk_level(triggers, total_value, max_concentration)
+
+        # Determine if approval is required
+        requires_approval = len(triggers) > 0
+        if self.config.auto_approve_low_risk and risk_level == RiskLevel.LOW:
+            requires_approval = False
+
+        logger.debug(
+            "recommendation_evaluated",
+            requires_approval=requires_approval,
+            risk_level=risk_level.value,
+            trigger_count=len(triggers),
+            triggers=[t.value for t in triggers],
+        )
+
+        return ApprovalEvaluation(
+            requires_approval=requires_approval,
+            risk_level=risk_level,
+            triggers=triggers,
+            details=details,
+        )
+
+    def _calculate_max_concentration(
+        self, trades: list[dict[str, Any]], portfolio_value: float
+    ) -> float:
+        """Calculate maximum position concentration after proposed trades."""
+        if portfolio_value <= 0:
+            return 0.0
+
+        # Group trades by symbol
+        position_values: dict[str, float] = {}
+        for trade in trades:
+            symbol = trade.get("symbol", "")
+            value = abs(trade.get("estimated_value", 0))
+            current_weight = trade.get("current_weight", 0) or 0
+            target_weight = trade.get("target_weight", 0) or 0
+
+            # Use target weight if available, otherwise estimate from value
+            if target_weight > 0:
+                position_values[symbol] = target_weight
+            else:
+                position_values[symbol] = max(
+                    current_weight,
+                    value / portfolio_value if portfolio_value > 0 else 0,
+                )
+
+        return max(position_values.values()) if position_values else 0.0
+
+    def _find_high_risk_assets(self, trades: list[dict[str, Any]]) -> list[str]:
+        """Find trades involving high-risk asset types."""
+        high_risk_symbols: list[str] = []
+
+        for trade in trades:
+            symbol = trade.get("symbol", "").upper()
+            # Check for common high-risk indicators in symbol names
+            # (In production, this would use asset classification data)
+            if any(
+                indicator in symbol
+                for indicator in ["X3", "X2", "3X", "2X", "TQQQ", "SQQQ", "SPXS", "SPXL"]
+            ):
+                high_risk_symbols.append(symbol)
+
+        return high_risk_symbols
+
+    def _find_new_symbols(
+        self, trades: list[dict[str, Any]], known_symbols: set[str]
+    ) -> list[str]:
+        """Find symbols that haven't been traded before."""
+        new_symbols: list[str] = []
+
+        for trade in trades:
+            symbol = trade.get("symbol", "").upper()
+            action = trade.get("action", "").lower()
+            # Only flag buy actions for new symbols
+            if action == "buy" and symbol not in known_symbols:
+                new_symbols.append(symbol)
+
+        return new_symbols
+
+    def _determine_risk_level(
+        self,
+        triggers: list[ApprovalTrigger],
+        total_value: float,
+        max_concentration: float,
+    ) -> RiskLevel:
+        """Determine overall risk level based on triggers and values."""
+        if not triggers:
+            return RiskLevel.LOW
+
+        # Critical if exceeds critical thresholds
+        if total_value > self.config.critical_value_threshold:
+            return RiskLevel.CRITICAL
+        if max_concentration > self.config.critical_concentration_threshold:
+            return RiskLevel.CRITICAL
+
+        # High if multiple triggers or high-risk assets
+        if len(triggers) >= 3:
+            return RiskLevel.HIGH
+        if ApprovalTrigger.HIGH_RISK_ASSET in triggers:
+            return RiskLevel.HIGH
+
+        # Medium for standard approval cases
+        if triggers:
+            return RiskLevel.MEDIUM
+
+        return RiskLevel.LOW
+
+    async def create_approval_request(
+        self,
+        workflow_id: str,
+        trace_id: str,
+        trades: list[dict[str, Any]],
+        portfolio_value: float,
+        compliance: dict[str, Any],
+        summary: str = "",
+        analysis_context: dict[str, Any] | None = None,
+        user_id: str | None = None,
+    ) -> ApprovalRequest:
+        """Create an approval request for a recommendation.
+
+        Args:
+            workflow_id: Associated workflow ID.
+            trace_id: Trace ID for observability.
+            trades: Proposed trades.
+            portfolio_value: Total portfolio value.
+            compliance: Compliance check results.
+            summary: Summary of the recommendation.
+            analysis_context: Additional context from analysis.
+            user_id: User who initiated the analysis.
+
+        Returns:
+            The created ApprovalRequest.
+        """
+        analysis_context = analysis_context or {}
+
+        # Evaluate the recommendation
+        evaluation = self.evaluate_recommendation(
+            trades=trades,
+            portfolio_value=portfolio_value,
+            compliance=compliance,
+            analysis_context=analysis_context,
+        )
+
+        # Calculate total trade value
+        total_value = sum(abs(t.get("estimated_value", 0)) for t in trades)
+
+        # Calculate expiration based on risk level
+        timeout_hours = (
+            self.config.critical_timeout_hours
+            if evaluation.risk_level == RiskLevel.CRITICAL
+            else self.config.default_timeout_hours
+        )
+        expires_at = datetime.now(UTC) + timedelta(hours=timeout_hours)
+
+        # Create the approval request
+        approval_request = ApprovalRequest(
+            workflow_id=workflow_id,
+            trace_id=trace_id,
+            user_id=user_id,
+            status=ApprovalStatus.PENDING,
+            risk_level=evaluation.risk_level,
+            triggers=evaluation.triggers,
+            trades=trades,
+            total_value=total_value,
+            portfolio_value=portfolio_value,
+            compliance=compliance,
+            summary=summary,
+            analysis_context={
+                **analysis_context,
+                "evaluation_details": evaluation.details,
+            },
+            expires_at=expires_at,
+        )
+
+        # Store the approval request
+        await self.persistence.save(approval_request)
+
+        logger.info(
+            "approval_request_created",
+            approval_id=approval_request.approval_id,
+            workflow_id=workflow_id,
+            risk_level=evaluation.risk_level.value,
+            trigger_count=len(evaluation.triggers),
+            expires_at=expires_at.isoformat(),
+        )
+
+        return approval_request
+
+    async def get_approval(self, approval_id: str) -> ApprovalRequest | None:
+        """Get an approval request by ID.
+
+        Args:
+            approval_id: The approval request ID.
+
+        Returns:
+            The ApprovalRequest if found, None otherwise.
+        """
+        return await self.persistence.get(approval_id)
+
+    async def get_approval_by_workflow(
+        self, workflow_id: str
+    ) -> ApprovalRequest | None:
+        """Get an approval request by workflow ID.
+
+        Args:
+            workflow_id: The workflow ID.
+
+        Returns:
+            The ApprovalRequest if found, None otherwise.
+        """
+        return await self.persistence.get_by_workflow(workflow_id)
+
+    async def list_pending(
+        self,
+        user_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[ApprovalRequest]:
+        """List pending approval requests.
+
+        Args:
+            user_id: Filter by user ID.
+            limit: Maximum number of results.
+            offset: Pagination offset.
+
+        Returns:
+            List of pending ApprovalRequests.
+        """
+        # First, expire any stale requests
+        await self._expire_stale_requests()
+
+        return await self.persistence.list_pending(
+            user_id=user_id, limit=limit, offset=offset
+        )
+
+    async def approve(
+        self,
+        approval_id: str,
+        reviewer_id: str,
+        reason: str | None = None,
+    ) -> ApprovalRequest | None:
+        """Approve a pending request.
+
+        Args:
+            approval_id: The approval request ID.
+            reviewer_id: ID of the reviewer.
+            reason: Optional reason for approval.
+
+        Returns:
+            The updated ApprovalRequest, or None if not found.
+        """
+        approval = await self.persistence.get(approval_id)
+        if approval is None:
+            logger.warning("approval_not_found", approval_id=approval_id)
+            return None
+
+        if not approval.is_pending():
+            logger.warning(
+                "approval_not_pending",
+                approval_id=approval_id,
+                status=approval.status.value,
+            )
+            return approval
+
+        if approval.is_expired():
+            approval.mark_expired()
+            await self.persistence.save(approval)
+            logger.warning("approval_expired", approval_id=approval_id)
+            return approval
+
+        approval.approve(reviewer_id=reviewer_id, reason=reason)
+        await self.persistence.save(approval)
+
+        logger.info(
+            "approval_approved",
+            approval_id=approval_id,
+            reviewer_id=reviewer_id,
+            workflow_id=approval.workflow_id,
+        )
+
+        return approval
+
+    async def reject(
+        self,
+        approval_id: str,
+        reviewer_id: str,
+        reason: str,
+    ) -> ApprovalRequest | None:
+        """Reject a pending request.
+
+        Args:
+            approval_id: The approval request ID.
+            reviewer_id: ID of the reviewer.
+            reason: Reason for rejection.
+
+        Returns:
+            The updated ApprovalRequest, or None if not found.
+        """
+        approval = await self.persistence.get(approval_id)
+        if approval is None:
+            logger.warning("approval_not_found", approval_id=approval_id)
+            return None
+
+        if not approval.is_pending():
+            logger.warning(
+                "approval_not_pending",
+                approval_id=approval_id,
+                status=approval.status.value,
+            )
+            return approval
+
+        if approval.is_expired():
+            approval.mark_expired()
+            await self.persistence.save(approval)
+            logger.warning("approval_expired", approval_id=approval_id)
+            return approval
+
+        approval.reject(reviewer_id=reviewer_id, reason=reason)
+        await self.persistence.save(approval)
+
+        logger.info(
+            "approval_rejected",
+            approval_id=approval_id,
+            reviewer_id=reviewer_id,
+            workflow_id=approval.workflow_id,
+            reason=reason,
+        )
+
+        return approval
+
+    async def modify(
+        self,
+        approval_id: str,
+        reviewer_id: str,
+        modified_trades: list[dict[str, Any]],
+        reason: str | None = None,
+    ) -> ApprovalRequest | None:
+        """Approve with modifications.
+
+        Args:
+            approval_id: The approval request ID.
+            reviewer_id: ID of the reviewer.
+            modified_trades: The modified trade list.
+            reason: Optional reason for modification.
+
+        Returns:
+            The updated ApprovalRequest, or None if not found.
+        """
+        approval = await self.persistence.get(approval_id)
+        if approval is None:
+            logger.warning("approval_not_found", approval_id=approval_id)
+            return None
+
+        if not approval.is_pending():
+            logger.warning(
+                "approval_not_pending",
+                approval_id=approval_id,
+                status=approval.status.value,
+            )
+            return approval
+
+        if approval.is_expired():
+            approval.mark_expired()
+            await self.persistence.save(approval)
+            logger.warning("approval_expired", approval_id=approval_id)
+            return approval
+
+        approval.modify(
+            reviewer_id=reviewer_id,
+            modified_trades=modified_trades,
+            reason=reason,
+        )
+        await self.persistence.save(approval)
+
+        logger.info(
+            "approval_modified",
+            approval_id=approval_id,
+            reviewer_id=reviewer_id,
+            workflow_id=approval.workflow_id,
+            modified_trade_count=len(modified_trades),
+        )
+
+        return approval
+
+    async def _expire_stale_requests(self) -> int:
+        """Expire stale pending requests.
+
+        Returns:
+            Number of requests expired.
+        """
+        expired_count = await self.persistence.expire_stale()
+        if expired_count > 0:
+            logger.info("stale_approvals_expired", count=expired_count)
+        return expired_count
+
+
+class ApprovalPersistence:
+    """Abstract base class for approval persistence."""
+
+    async def save(self, approval: ApprovalRequest) -> None:
+        """Save an approval request."""
+        raise NotImplementedError
+
+    async def get(self, approval_id: str) -> ApprovalRequest | None:
+        """Get an approval request by ID."""
+        raise NotImplementedError
+
+    async def get_by_workflow(self, workflow_id: str) -> ApprovalRequest | None:
+        """Get an approval request by workflow ID."""
+        raise NotImplementedError
+
+    async def list_pending(
+        self,
+        user_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[ApprovalRequest]:
+        """List pending approval requests."""
+        raise NotImplementedError
+
+    async def expire_stale(self) -> int:
+        """Expire stale pending requests."""
+        raise NotImplementedError
+
+
+class InMemoryApprovalPersistence(ApprovalPersistence):
+    """In-memory persistence for development and testing."""
+
+    def __init__(self) -> None:
+        """Initialize in-memory storage."""
+        self._approvals: dict[str, ApprovalRequest] = {}
+        self._by_workflow: dict[str, str] = {}
+
+    async def save(self, approval: ApprovalRequest) -> None:
+        """Save an approval request."""
+        self._approvals[approval.approval_id] = approval
+        self._by_workflow[approval.workflow_id] = approval.approval_id
+
+    async def get(self, approval_id: str) -> ApprovalRequest | None:
+        """Get an approval request by ID."""
+        return self._approvals.get(approval_id)
+
+    async def get_by_workflow(self, workflow_id: str) -> ApprovalRequest | None:
+        """Get an approval request by workflow ID."""
+        approval_id = self._by_workflow.get(workflow_id)
+        if approval_id:
+            return self._approvals.get(approval_id)
+        return None
+
+    async def list_pending(
+        self,
+        user_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[ApprovalRequest]:
+        """List pending approval requests."""
+        pending = [
+            a
+            for a in self._approvals.values()
+            if a.status == ApprovalStatus.PENDING
+            and (user_id is None or a.user_id == user_id)
+        ]
+        # Sort by created_at descending
+        pending.sort(key=lambda a: a.created_at, reverse=True)
+        return pending[offset : offset + limit]
+
+    async def expire_stale(self) -> int:
+        """Expire stale pending requests."""
+        expired_count = 0
+        now = datetime.now(UTC)
+
+        for approval in self._approvals.values():
+            if approval.is_pending() and approval.expires_at and now > approval.expires_at:
+                approval.mark_expired()
+                expired_count += 1
+
+        return expired_count
+
+
+class PostgresApprovalPersistence(ApprovalPersistence):
+    """PostgreSQL persistence for production use."""
+
+    def __init__(self, connection_string: str | None = None) -> None:
+        """Initialize PostgreSQL persistence.
+
+        Args:
+            connection_string: PostgreSQL connection string.
+                If not provided, uses DATABASE_URL environment variable.
+        """
+        import os
+
+        self.connection_string = connection_string or os.getenv(
+            "DATABASE_URL", "postgresql://localhost:5432/portfolio_advisor"
+        )
+        self._pool: Any = None
+
+    async def _get_pool(self) -> Any:
+        """Get or create connection pool."""
+        if self._pool is None:
+            try:
+                import asyncpg
+
+                self._pool = await asyncpg.create_pool(
+                    self.connection_string,
+                    min_size=2,
+                    max_size=10,
+                )
+                logger.info("approval_database_pool_created")
+            except ImportError:
+                logger.warning(
+                    "asyncpg_not_installed",
+                    message="PostgreSQL approval persistence disabled",
+                )
+                raise
+            except Exception as e:
+                logger.error("approval_database_pool_failed", error=str(e))
+                raise
+
+        return self._pool
+
+    async def initialize_schema(self) -> None:
+        """Create the approval_requests table if it doesn't exist."""
+        pool = await self._get_pool()
+
+        create_table_sql = """
+        CREATE TABLE IF NOT EXISTS approval_requests (
+            approval_id UUID PRIMARY KEY,
+            workflow_id UUID NOT NULL,
+            trace_id UUID NOT NULL,
+            user_id TEXT,
+            status TEXT NOT NULL,
+            risk_level TEXT NOT NULL,
+            triggers TEXT[] NOT NULL DEFAULT '{}',
+            trades JSONB NOT NULL DEFAULT '[]'::jsonb,
+            total_value NUMERIC NOT NULL DEFAULT 0,
+            portfolio_value NUMERIC NOT NULL DEFAULT 0,
+            compliance JSONB NOT NULL DEFAULT '{}'::jsonb,
+            summary TEXT,
+            analysis_context JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            expires_at TIMESTAMPTZ,
+            decision JSONB,
+            updated_at TIMESTAMPTZ DEFAULT NOW()
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_approval_requests_workflow_id
+            ON approval_requests(workflow_id);
+        CREATE INDEX IF NOT EXISTS idx_approval_requests_status
+            ON approval_requests(status);
+        CREATE INDEX IF NOT EXISTS idx_approval_requests_user_id
+            ON approval_requests(user_id);
+        CREATE INDEX IF NOT EXISTS idx_approval_requests_created_at
+            ON approval_requests(created_at);
+        CREATE INDEX IF NOT EXISTS idx_approval_requests_expires_at
+            ON approval_requests(expires_at);
+        """
+
+        async with pool.acquire() as conn:
+            await conn.execute(create_table_sql)
+            logger.info("approval_schema_initialized")
+
+    async def save(self, approval: ApprovalRequest) -> None:
+        """Save an approval request."""
+        pool = await self._get_pool()
+
+        upsert_sql = """
+        INSERT INTO approval_requests (
+            approval_id, workflow_id, trace_id, user_id, status, risk_level,
+            triggers, trades, total_value, portfolio_value, compliance,
+            summary, analysis_context, created_at, expires_at, decision, updated_at
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NOW()
+        )
+        ON CONFLICT (approval_id) DO UPDATE SET
+            status = EXCLUDED.status,
+            decision = EXCLUDED.decision,
+            updated_at = NOW()
+        """
+
+        import uuid as uuid_lib
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                upsert_sql,
+                uuid_lib.UUID(approval.approval_id),
+                uuid_lib.UUID(approval.workflow_id),
+                uuid_lib.UUID(approval.trace_id),
+                approval.user_id,
+                approval.status.value,
+                approval.risk_level.value,
+                [t.value for t in approval.triggers],
+                json.dumps([dict(t) for t in approval.trades]),
+                approval.total_value,
+                approval.portfolio_value,
+                json.dumps(approval.compliance),
+                approval.summary,
+                json.dumps(approval.analysis_context),
+                approval.created_at,
+                approval.expires_at,
+                json.dumps(approval.decision.model_dump(mode="json"))
+                if approval.decision
+                else None,
+            )
+
+        logger.debug("approval_saved", approval_id=approval.approval_id)
+
+    async def get(self, approval_id: str) -> ApprovalRequest | None:
+        """Get an approval request by ID."""
+        pool = await self._get_pool()
+
+        import uuid as uuid_lib
+
+        select_sql = """
+        SELECT approval_id, workflow_id, trace_id, user_id, status, risk_level,
+               triggers, trades, total_value, portfolio_value, compliance,
+               summary, analysis_context, created_at, expires_at, decision
+        FROM approval_requests
+        WHERE approval_id = $1
+        """
+
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(select_sql, uuid_lib.UUID(approval_id))
+
+        if not row:
+            return None
+
+        return self._row_to_approval(row)
+
+    async def get_by_workflow(self, workflow_id: str) -> ApprovalRequest | None:
+        """Get an approval request by workflow ID."""
+        pool = await self._get_pool()
+
+        import uuid as uuid_lib
+
+        select_sql = """
+        SELECT approval_id, workflow_id, trace_id, user_id, status, risk_level,
+               triggers, trades, total_value, portfolio_value, compliance,
+               summary, analysis_context, created_at, expires_at, decision
+        FROM approval_requests
+        WHERE workflow_id = $1
+        ORDER BY created_at DESC
+        LIMIT 1
+        """
+
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(select_sql, uuid_lib.UUID(workflow_id))
+
+        if not row:
+            return None
+
+        return self._row_to_approval(row)
+
+    async def list_pending(
+        self,
+        user_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[ApprovalRequest]:
+        """List pending approval requests."""
+        pool = await self._get_pool()
+
+        conditions = ["status = 'pending'"]
+        params: list[Any] = []
+        param_idx = 1
+
+        if user_id:
+            conditions.append(f"user_id = ${param_idx}")
+            params.append(user_id)
+            param_idx += 1
+
+        where_clause = " AND ".join(conditions)
+
+        select_sql = f"""
+        SELECT approval_id, workflow_id, trace_id, user_id, status, risk_level,
+               triggers, trades, total_value, portfolio_value, compliance,
+               summary, analysis_context, created_at, expires_at, decision
+        FROM approval_requests
+        WHERE {where_clause}
+        ORDER BY created_at DESC
+        LIMIT ${param_idx} OFFSET ${param_idx + 1}
+        """
+        params.extend([limit, offset])
+
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(select_sql, *params)
+
+        return [self._row_to_approval(row) for row in rows]
+
+    async def expire_stale(self) -> int:
+        """Expire stale pending requests."""
+        pool = await self._get_pool()
+
+        update_sql = """
+        UPDATE approval_requests
+        SET status = 'expired', updated_at = NOW()
+        WHERE status = 'pending'
+          AND expires_at IS NOT NULL
+          AND expires_at < NOW()
+        """
+
+        async with pool.acquire() as conn:
+            result = await conn.execute(update_sql)
+
+        # Parse the result to get affected rows
+        if result.startswith("UPDATE "):
+            return int(result.split()[1])
+        return 0
+
+    def _row_to_approval(self, row: Any) -> ApprovalRequest:
+        """Convert a database row to an ApprovalRequest."""
+        from src.approval.models import ApprovalDecision
+
+        decision = None
+        if row["decision"]:
+            decision_data = json.loads(row["decision"])
+            decision = ApprovalDecision(**decision_data)
+
+        return ApprovalRequest(
+            approval_id=str(row["approval_id"]),
+            workflow_id=str(row["workflow_id"]),
+            trace_id=str(row["trace_id"]),
+            user_id=row["user_id"],
+            status=ApprovalStatus(row["status"]),
+            risk_level=RiskLevel(row["risk_level"]),
+            triggers=[ApprovalTrigger(t) for t in row["triggers"]],
+            trades=json.loads(row["trades"]),
+            total_value=float(row["total_value"]),
+            portfolio_value=float(row["portfolio_value"]),
+            compliance=json.loads(row["compliance"]),
+            summary=row["summary"] or "",
+            analysis_context=json.loads(row["analysis_context"]),
+            created_at=row["created_at"],
+            expires_at=row["expires_at"],
+            decision=decision,
+        )
+
+    async def close(self) -> None:
+        """Close the connection pool."""
+        if self._pool:
+            await self._pool.close()
+            self._pool = None
+            logger.info("approval_database_pool_closed")

--- a/src/approval/models.py
+++ b/src/approval/models.py
@@ -1,0 +1,230 @@
+"""Approval request models and types.
+
+This module defines the data models for the human approval workflow.
+"""
+
+import uuid
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ApprovalStatus(str, Enum):
+    """Status of an approval request."""
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    EXPIRED = "expired"
+    MODIFIED = "modified"
+
+
+class RiskLevel(str, Enum):
+    """Risk level classification for recommendations."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ApprovalTrigger(str, Enum):
+    """Reasons that triggered the approval requirement."""
+
+    HIGH_VALUE_TRADE = "high_value_trade"
+    HIGH_CONCENTRATION = "high_concentration"
+    HIGH_RISK_ASSET = "high_risk_asset"
+    FIRST_TIME_SYMBOL = "first_time_symbol"
+    LOW_CONFIDENCE = "low_confidence"
+    COMPLIANCE_WARNING = "compliance_warning"
+    MANUAL_REVIEW = "manual_review"
+
+
+class ApprovalDecision(BaseModel):
+    """A human reviewer's decision on an approval request."""
+
+    status: ApprovalStatus = Field(
+        ..., description="Decision: approved, rejected, or modified"
+    )
+    reviewer_id: str = Field(..., description="Identifier of the reviewer")
+    reason: str | None = Field(
+        default=None, description="Reason for rejection or modification"
+    )
+    modified_trades: list[dict[str, Any]] | None = Field(
+        default=None, description="Modified trades (if status is modified)"
+    )
+    decided_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="When the decision was made",
+    )
+
+
+class ApprovalRequest(BaseModel):
+    """A request for human approval of high-risk recommendations.
+
+    This model tracks the full lifecycle of an approval request from
+    creation through final decision.
+    """
+
+    # Identifiers
+    approval_id: str = Field(
+        default_factory=lambda: str(uuid.uuid4()),
+        description="Unique identifier for this approval request",
+    )
+    workflow_id: str = Field(..., description="Associated workflow ID")
+    trace_id: str = Field(..., description="Trace ID for observability")
+    user_id: str | None = Field(default=None, description="User who initiated analysis")
+
+    # Status tracking
+    status: ApprovalStatus = Field(
+        default=ApprovalStatus.PENDING,
+        description="Current status of the approval request",
+    )
+
+    # Risk assessment
+    risk_level: RiskLevel = Field(
+        default=RiskLevel.MEDIUM, description="Overall risk level"
+    )
+    triggers: list[ApprovalTrigger] = Field(
+        default_factory=list,
+        description="Reasons that triggered approval requirement",
+    )
+
+    # Recommendation data
+    trades: list[dict[str, Any]] = Field(
+        default_factory=list, description="Proposed trades requiring approval"
+    )
+    total_value: float = Field(
+        default=0.0, description="Total value of proposed trades"
+    )
+    portfolio_value: float = Field(
+        default=0.0, description="Total portfolio value for context"
+    )
+    compliance: dict[str, Any] = Field(
+        default_factory=dict, description="Compliance check results"
+    )
+
+    # Context
+    summary: str = Field(
+        default="", description="Summary of the recommendation"
+    )
+    analysis_context: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional context from analysis (risk metrics, etc.)",
+    )
+
+    # Timestamps
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="When the approval request was created",
+    )
+    expires_at: datetime | None = Field(
+        default=None,
+        description="When the approval request expires (if not acted upon)",
+    )
+
+    # Decision
+    decision: ApprovalDecision | None = Field(
+        default=None, description="Human reviewer's decision"
+    )
+
+    def is_pending(self) -> bool:
+        """Check if the request is still pending."""
+        return self.status == ApprovalStatus.PENDING
+
+    def is_expired(self) -> bool:
+        """Check if the request has expired."""
+        if self.expires_at is None:
+            return False
+        return datetime.now(UTC) > self.expires_at
+
+    def approve(self, reviewer_id: str, reason: str | None = None) -> None:
+        """Approve the request."""
+        self.status = ApprovalStatus.APPROVED
+        self.decision = ApprovalDecision(
+            status=ApprovalStatus.APPROVED,
+            reviewer_id=reviewer_id,
+            reason=reason,
+        )
+
+    def reject(self, reviewer_id: str, reason: str) -> None:
+        """Reject the request."""
+        self.status = ApprovalStatus.REJECTED
+        self.decision = ApprovalDecision(
+            status=ApprovalStatus.REJECTED,
+            reviewer_id=reviewer_id,
+            reason=reason,
+        )
+
+    def modify(
+        self,
+        reviewer_id: str,
+        modified_trades: list[dict[str, Any]],
+        reason: str | None = None,
+    ) -> None:
+        """Approve with modifications."""
+        self.status = ApprovalStatus.MODIFIED
+        self.decision = ApprovalDecision(
+            status=ApprovalStatus.MODIFIED,
+            reviewer_id=reviewer_id,
+            reason=reason,
+            modified_trades=modified_trades,
+        )
+
+    def mark_expired(self) -> None:
+        """Mark the request as expired."""
+        self.status = ApprovalStatus.EXPIRED
+
+
+class ApprovalConfig(BaseModel):
+    """Configuration for approval thresholds and rules."""
+
+    # Value thresholds
+    high_value_threshold: float = Field(
+        default=10000.0,
+        description="Trade value threshold that triggers approval ($)",
+    )
+    critical_value_threshold: float = Field(
+        default=50000.0,
+        description="Trade value threshold for critical risk level ($)",
+    )
+
+    # Concentration thresholds
+    concentration_threshold: float = Field(
+        default=0.20,
+        description="Portfolio concentration threshold (20%)",
+    )
+    critical_concentration_threshold: float = Field(
+        default=0.30,
+        description="Critical concentration threshold (30%)",
+    )
+
+    # Confidence thresholds
+    low_confidence_threshold: float = Field(
+        default=0.7,
+        description="Confidence score below which approval is required",
+    )
+
+    # High-risk asset classes
+    high_risk_asset_types: list[str] = Field(
+        default_factory=lambda: ["options", "leveraged_etf", "inverse_etf", "crypto"],
+        description="Asset types that always require approval",
+    )
+
+    # Timeout configuration
+    default_timeout_hours: int = Field(
+        default=24,
+        description="Default timeout for pending approvals (hours)",
+    )
+    critical_timeout_hours: int = Field(
+        default=4,
+        description="Timeout for critical risk approvals (hours)",
+    )
+
+    # Auto-approval settings
+    auto_approve_low_risk: bool = Field(
+        default=True,
+        description="Automatically approve low-risk trades",
+    )

--- a/tests/test_approval/__init__.py
+++ b/tests/test_approval/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the approval workflow module."""

--- a/tests/test_approval/test_api.py
+++ b/tests/test_approval/test_api.py
@@ -1,0 +1,326 @@
+"""Tests for approval API endpoints."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.approvals import router
+from src.api.health import reset_health_service
+from src.api.routes import create_app
+from src.approval.manager import ApprovalManager, InMemoryApprovalPersistence
+from src.approval.models import (
+    ApprovalConfig,
+    ApprovalRequest,
+    ApprovalStatus,
+    ApprovalTrigger,
+    RiskLevel,
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def test_manager():
+    """Create test approval manager."""
+    config = ApprovalConfig(
+        high_value_threshold=5000.0,
+        concentration_threshold=0.15,
+    )
+    return ApprovalManager(config=config)
+
+
+@pytest.fixture
+def app(test_manager):
+    """Create test FastAPI app with approval routes."""
+    reset_health_service()
+    application = create_app(title="Test API", version="0.1.0")
+
+    # Patch the approval manager
+    with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+        yield application
+
+
+@pytest.fixture
+def client(app):
+    """Create test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def sample_approval():
+    """Create sample approval request."""
+    return ApprovalRequest(
+        workflow_id="wf-123",
+        trace_id="trace-456",
+        user_id="user-789",
+        risk_level=RiskLevel.HIGH,
+        triggers=[ApprovalTrigger.HIGH_VALUE_TRADE],
+        trades=[
+            {
+                "symbol": "AAPL",
+                "action": "buy",
+                "quantity": 100,
+                "estimated_value": 15000.0,
+            }
+        ],
+        total_value=15000.0,
+        portfolio_value=100000.0,
+        compliance={"is_compliant": True, "warnings": []},
+        summary="Buy AAPL",
+    )
+
+
+# ============================================================================
+# List Approvals Tests
+# ============================================================================
+
+
+class TestListApprovals:
+    """Tests for GET /approvals endpoint."""
+
+    def test_list_empty(self, client, test_manager):
+        """Test listing when no approvals exist."""
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.get("/approvals")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    @pytest.mark.asyncio
+    async def test_list_with_approvals(self, client, test_manager, sample_approval):
+        """Test listing with existing approvals."""
+        # Add approval to persistence
+        await test_manager.persistence.save(sample_approval)
+
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.get("/approvals")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["approval_id"] == sample_approval.approval_id
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_user(self, client, test_manager):
+        """Test filtering by user_id."""
+        # Create approvals for different users
+        approval_a = ApprovalRequest(
+            workflow_id="wf-1",
+            trace_id="trace-1",
+            user_id="user-A",
+            trades=[],
+            compliance={},
+        )
+        approval_b = ApprovalRequest(
+            workflow_id="wf-2",
+            trace_id="trace-2",
+            user_id="user-B",
+            trades=[],
+            compliance={},
+        )
+
+        await test_manager.persistence.save(approval_a)
+        await test_manager.persistence.save(approval_b)
+
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.get("/approvals", params={"user_id": "user-A"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["workflow_id"] == "wf-1"
+
+
+# ============================================================================
+# Get Approval Tests
+# ============================================================================
+
+
+class TestGetApproval:
+    """Tests for GET /approvals/{approval_id} endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_approval_success(self, client, test_manager, sample_approval):
+        """Test getting an existing approval."""
+        await test_manager.persistence.save(sample_approval)
+
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.get(f"/approvals/{sample_approval.approval_id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["approval_id"] == sample_approval.approval_id
+        assert data["workflow_id"] == "wf-123"
+        assert data["status"] == "pending"
+        assert data["risk_level"] == "high"
+        assert len(data["trades"]) == 1
+
+    def test_get_approval_not_found(self, client, test_manager):
+        """Test getting a non-existent approval."""
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.get("/approvals/non-existent-id")
+
+        assert response.status_code == 404
+        data = response.json()
+        # Error message is in 'error' field (from ErrorResponse model)
+        error_message = data.get("detail") or data.get("error", "")
+        assert "not found" in error_message
+
+
+# ============================================================================
+# Approve Tests
+# ============================================================================
+
+
+class TestApproveEndpoint:
+    """Tests for POST /approvals/{approval_id}/approve endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_approve_success(self, client, test_manager, sample_approval):
+        """Test approving an approval request."""
+        await test_manager.persistence.save(sample_approval)
+
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.post(
+                f"/approvals/{sample_approval.approval_id}/approve",
+                json={"reviewer_id": "reviewer-123", "reason": "Approved"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "approved"
+        assert data["message"] == "Recommendation approved successfully"
+
+    def test_approve_not_found(self, client, test_manager):
+        """Test approving a non-existent approval."""
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.post(
+                "/approvals/non-existent-id/approve",
+                json={"reviewer_id": "reviewer-123"},
+            )
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_approve_already_approved(self, client, test_manager, sample_approval):
+        """Test approving an already approved request - returns 400."""
+        sample_approval.approve(reviewer_id="previous-reviewer")
+        await test_manager.persistence.save(sample_approval)
+
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.post(
+                f"/approvals/{sample_approval.approval_id}/approve",
+                json={"reviewer_id": "reviewer-123"},
+            )
+
+        # API returns 400 because it's not pending
+        assert response.status_code == 400
+        data = response.json()
+        # Error message is in 'error' field (from ErrorResponse model)
+        error_message = data.get("detail") or data.get("error", "")
+        assert "not in pending status" in error_message
+
+
+# ============================================================================
+# Reject Tests
+# ============================================================================
+
+
+class TestRejectEndpoint:
+    """Tests for POST /approvals/{approval_id}/reject endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_reject_success(self, client, test_manager, sample_approval):
+        """Test rejecting an approval request."""
+        await test_manager.persistence.save(sample_approval)
+
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.post(
+                f"/approvals/{sample_approval.approval_id}/reject",
+                json={"reviewer_id": "reviewer-456", "reason": "Too risky"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "rejected"
+        assert data["message"] == "Recommendation rejected"
+
+    def test_reject_not_found(self, client, test_manager):
+        """Test rejecting a non-existent approval."""
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.post(
+                "/approvals/non-existent-id/reject",
+                json={"reviewer_id": "reviewer-456", "reason": "Not found"},
+            )
+
+        assert response.status_code == 404
+
+    def test_reject_requires_reason(self, client, test_manager):
+        """Test that reject requires a reason."""
+        # FastAPI validation should fail without reason
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.post(
+                "/approvals/some-id/reject",
+                json={"reviewer_id": "reviewer-456"},  # Missing reason
+            )
+
+        assert response.status_code == 422  # Validation error
+
+
+# ============================================================================
+# Modify Tests
+# ============================================================================
+
+
+class TestModifyEndpoint:
+    """Tests for POST /approvals/{approval_id}/modify endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_modify_success(self, client, test_manager, sample_approval):
+        """Test modifying an approval request."""
+        await test_manager.persistence.save(sample_approval)
+
+        modified_trades = [{"symbol": "AAPL", "action": "buy", "quantity": 50}]
+
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.post(
+                f"/approvals/{sample_approval.approval_id}/modify",
+                json={
+                    "reviewer_id": "reviewer-789",
+                    "modified_trades": modified_trades,
+                    "reason": "Reduced quantity",
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "modified"
+        assert data["message"] == "Recommendation approved with modifications"
+
+    def test_modify_not_found(self, client, test_manager):
+        """Test modifying a non-existent approval."""
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.post(
+                "/approvals/non-existent-id/modify",
+                json={
+                    "reviewer_id": "reviewer-789",
+                    "modified_trades": [],
+                },
+            )
+
+        assert response.status_code == 404
+
+    def test_modify_requires_trades(self, client, test_manager):
+        """Test that modify requires modified_trades."""
+        # FastAPI validation should fail without modified_trades
+        with patch("src.api.approvals.get_approval_manager", return_value=test_manager):
+            response = client.post(
+                "/approvals/some-id/modify",
+                json={"reviewer_id": "reviewer-789"},  # Missing modified_trades
+            )
+
+        assert response.status_code == 422  # Validation error

--- a/tests/test_approval/test_manager.py
+++ b/tests/test_approval/test_manager.py
@@ -1,0 +1,609 @@
+"""Tests for approval manager."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.approval.manager import (
+    ApprovalConfig,
+    ApprovalEvaluation,
+    ApprovalManager,
+    InMemoryApprovalPersistence,
+)
+from src.approval.models import (
+    ApprovalRequest,
+    ApprovalStatus,
+    ApprovalTrigger,
+    RiskLevel,
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def config():
+    """Create test config with lower thresholds."""
+    return ApprovalConfig(
+        high_value_threshold=5000.0,
+        critical_value_threshold=25000.0,
+        concentration_threshold=0.15,
+        critical_concentration_threshold=0.25,
+        low_confidence_threshold=0.7,
+        default_timeout_hours=24,
+        critical_timeout_hours=4,
+        auto_approve_low_risk=True,
+    )
+
+
+@pytest.fixture
+def manager(config):
+    """Create test approval manager."""
+    return ApprovalManager(config=config)
+
+
+@pytest.fixture
+def sample_low_value_trades():
+    """Sample low value trades that don't require approval."""
+    return [
+        {
+            "symbol": "AAPL",
+            "action": "buy",
+            "quantity": 10,
+            "estimated_value": 1000.0,
+            "target_weight": 0.05,
+            "current_weight": 0.04,
+        },
+    ]
+
+
+@pytest.fixture
+def sample_high_value_trades():
+    """Sample high value trades that require approval."""
+    return [
+        {
+            "symbol": "AAPL",
+            "action": "buy",
+            "quantity": 100,
+            "estimated_value": 15000.0,
+            "target_weight": 0.18,
+            "current_weight": 0.10,
+        },
+    ]
+
+
+@pytest.fixture
+def sample_high_concentration_trades():
+    """Sample trades with high concentration."""
+    return [
+        {
+            "symbol": "AAPL",
+            "action": "buy",
+            "quantity": 50,
+            "estimated_value": 3000.0,
+            "target_weight": 0.30,
+            "current_weight": 0.10,
+        },
+    ]
+
+
+@pytest.fixture
+def sample_compliance_clean():
+    """Sample clean compliance result."""
+    return {
+        "is_compliant": True,
+        "violations": [],
+        "warnings": [],
+        "requires_approval": False,
+    }
+
+
+@pytest.fixture
+def sample_compliance_with_warnings():
+    """Sample compliance with warnings."""
+    return {
+        "is_compliant": True,
+        "violations": [],
+        "warnings": ["High sector concentration"],
+        "requires_approval": True,
+    }
+
+
+# ============================================================================
+# ApprovalEvaluation Tests
+# ============================================================================
+
+
+class TestApprovalEvaluation:
+    """Tests for ApprovalEvaluation."""
+
+    def test_no_approval_for_low_value(
+        self, manager, sample_low_value_trades, sample_compliance_clean
+    ):
+        """Test that low value trades don't require approval."""
+        evaluation = manager.evaluate_recommendation(
+            trades=sample_low_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+            known_symbols={"AAPL"},  # Mark AAPL as known to avoid first-time trigger
+        )
+
+        assert evaluation.requires_approval is False
+        assert evaluation.risk_level == RiskLevel.LOW
+        assert len(evaluation.triggers) == 0
+
+    def test_approval_required_for_high_value(
+        self, manager, sample_high_value_trades, sample_compliance_clean
+    ):
+        """Test that high value trades require approval."""
+        evaluation = manager.evaluate_recommendation(
+            trades=sample_high_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+        )
+
+        assert evaluation.requires_approval is True
+        assert ApprovalTrigger.HIGH_VALUE_TRADE in evaluation.triggers
+        assert evaluation.details["total_trade_value"] == 15000.0
+
+    def test_approval_required_for_high_concentration(
+        self, manager, sample_high_concentration_trades, sample_compliance_clean
+    ):
+        """Test that high concentration triggers approval."""
+        evaluation = manager.evaluate_recommendation(
+            trades=sample_high_concentration_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+        )
+
+        assert evaluation.requires_approval is True
+        assert ApprovalTrigger.HIGH_CONCENTRATION in evaluation.triggers
+
+    def test_approval_required_for_compliance_warnings(
+        self, manager, sample_low_value_trades, sample_compliance_with_warnings
+    ):
+        """Test that compliance warnings trigger approval."""
+        evaluation = manager.evaluate_recommendation(
+            trades=sample_low_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_with_warnings,
+        )
+
+        assert evaluation.requires_approval is True
+        assert ApprovalTrigger.COMPLIANCE_WARNING in evaluation.triggers
+
+    def test_approval_for_low_confidence(
+        self, manager, sample_low_value_trades, sample_compliance_clean
+    ):
+        """Test that low confidence triggers approval."""
+        evaluation = manager.evaluate_recommendation(
+            trades=sample_low_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+            confidence_score=0.5,  # Below threshold of 0.7
+        )
+
+        assert evaluation.requires_approval is True
+        assert ApprovalTrigger.LOW_CONFIDENCE in evaluation.triggers
+
+    def test_approval_for_first_time_symbol(
+        self, manager, sample_low_value_trades, sample_compliance_clean
+    ):
+        """Test that first-time symbols trigger approval."""
+        evaluation = manager.evaluate_recommendation(
+            trades=sample_low_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+            known_symbols={"GOOGL", "MSFT"},  # AAPL is not known
+        )
+
+        assert evaluation.requires_approval is True
+        assert ApprovalTrigger.FIRST_TIME_SYMBOL in evaluation.triggers
+        assert "AAPL" in evaluation.details["new_symbols"]
+
+    def test_high_risk_assets_detected(self, manager, sample_compliance_clean):
+        """Test that high-risk assets are detected."""
+        high_risk_trades = [
+            {
+                "symbol": "TQQQ",
+                "action": "buy",
+                "quantity": 100,
+                "estimated_value": 3000.0,
+            },
+        ]
+
+        evaluation = manager.evaluate_recommendation(
+            trades=high_risk_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+        )
+
+        assert evaluation.requires_approval is True
+        assert ApprovalTrigger.HIGH_RISK_ASSET in evaluation.triggers
+        assert "TQQQ" in evaluation.details["high_risk_assets"]
+
+    def test_critical_risk_level(self, manager, sample_compliance_clean):
+        """Test that critical value triggers critical risk level."""
+        critical_trades = [
+            {
+                "symbol": "AAPL",
+                "action": "buy",
+                "quantity": 500,
+                "estimated_value": 30000.0,  # Above critical threshold of 25000
+            },
+        ]
+
+        evaluation = manager.evaluate_recommendation(
+            trades=critical_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+        )
+
+        assert evaluation.risk_level == RiskLevel.CRITICAL
+
+    def test_multiple_triggers_high_risk(self, manager, sample_compliance_with_warnings):
+        """Test that multiple triggers result in high risk."""
+        multi_issue_trades = [
+            {
+                "symbol": "AAPL",
+                "action": "buy",
+                "quantity": 100,
+                "estimated_value": 10000.0,
+                "target_weight": 0.20,
+            },
+        ]
+
+        evaluation = manager.evaluate_recommendation(
+            trades=multi_issue_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_with_warnings,
+            confidence_score=0.5,  # Low confidence
+        )
+
+        # Should have at least 3 triggers: high_value, high_concentration, compliance, low_confidence
+        assert len(evaluation.triggers) >= 3
+        assert evaluation.risk_level in [RiskLevel.HIGH, RiskLevel.CRITICAL]
+
+
+# ============================================================================
+# ApprovalManager Create/Get Tests
+# ============================================================================
+
+
+class TestApprovalManagerCreateGet:
+    """Tests for creating and retrieving approvals."""
+
+    @pytest.mark.asyncio
+    async def test_create_approval_request(
+        self, manager, sample_high_value_trades, sample_compliance_clean
+    ):
+        """Test creating an approval request."""
+        approval = await manager.create_approval_request(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_high_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+            summary="Test approval",
+            user_id="user-789",
+        )
+
+        assert approval.approval_id is not None
+        assert approval.workflow_id == "wf-123"
+        assert approval.trace_id == "trace-456"
+        assert approval.user_id == "user-789"
+        assert approval.status == ApprovalStatus.PENDING
+        assert approval.expires_at is not None
+        assert len(approval.trades) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_approval(
+        self, manager, sample_high_value_trades, sample_compliance_clean
+    ):
+        """Test retrieving an approval by ID."""
+        approval = await manager.create_approval_request(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_high_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+        )
+
+        retrieved = await manager.get_approval(approval.approval_id)
+
+        assert retrieved is not None
+        assert retrieved.approval_id == approval.approval_id
+
+    @pytest.mark.asyncio
+    async def test_get_approval_not_found(self, manager):
+        """Test retrieving a non-existent approval."""
+        retrieved = await manager.get_approval("non-existent-id")
+        assert retrieved is None
+
+    @pytest.mark.asyncio
+    async def test_get_approval_by_workflow(
+        self, manager, sample_high_value_trades, sample_compliance_clean
+    ):
+        """Test retrieving an approval by workflow ID."""
+        approval = await manager.create_approval_request(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_high_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+        )
+
+        retrieved = await manager.get_approval_by_workflow("wf-123")
+
+        assert retrieved is not None
+        assert retrieved.workflow_id == "wf-123"
+
+    @pytest.mark.asyncio
+    async def test_list_pending(
+        self, manager, sample_high_value_trades, sample_compliance_clean
+    ):
+        """Test listing pending approvals."""
+        # Create multiple approvals
+        await manager.create_approval_request(
+            workflow_id="wf-1",
+            trace_id="trace-1",
+            trades=sample_high_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+            user_id="user-A",
+        )
+        await manager.create_approval_request(
+            workflow_id="wf-2",
+            trace_id="trace-2",
+            trades=sample_high_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+            user_id="user-B",
+        )
+
+        # List all pending
+        pending = await manager.list_pending()
+        assert len(pending) == 2
+
+        # List by user
+        pending_user_a = await manager.list_pending(user_id="user-A")
+        assert len(pending_user_a) == 1
+        assert pending_user_a[0].user_id == "user-A"
+
+
+# ============================================================================
+# ApprovalManager Decision Tests
+# ============================================================================
+
+
+class TestApprovalManagerDecisions:
+    """Tests for approval decisions."""
+
+    @pytest.mark.asyncio
+    async def test_approve(
+        self, manager, sample_high_value_trades, sample_compliance_clean
+    ):
+        """Test approving a request."""
+        approval = await manager.create_approval_request(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_high_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+        )
+
+        result = await manager.approve(
+            approval_id=approval.approval_id,
+            reviewer_id="reviewer-123",
+            reason="Looks good",
+        )
+
+        assert result is not None
+        assert result.status == ApprovalStatus.APPROVED
+        assert result.decision is not None
+        assert result.decision.reviewer_id == "reviewer-123"
+
+    @pytest.mark.asyncio
+    async def test_reject(
+        self, manager, sample_high_value_trades, sample_compliance_clean
+    ):
+        """Test rejecting a request."""
+        approval = await manager.create_approval_request(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_high_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+        )
+
+        result = await manager.reject(
+            approval_id=approval.approval_id,
+            reviewer_id="reviewer-456",
+            reason="Too risky",
+        )
+
+        assert result is not None
+        assert result.status == ApprovalStatus.REJECTED
+        assert result.decision.reason == "Too risky"
+
+    @pytest.mark.asyncio
+    async def test_modify(
+        self, manager, sample_high_value_trades, sample_compliance_clean
+    ):
+        """Test modifying a request."""
+        approval = await manager.create_approval_request(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_high_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+        )
+
+        modified_trades = [{"symbol": "AAPL", "action": "buy", "quantity": 50}]
+        result = await manager.modify(
+            approval_id=approval.approval_id,
+            reviewer_id="reviewer-789",
+            modified_trades=modified_trades,
+            reason="Reduced quantity",
+        )
+
+        assert result is not None
+        assert result.status == ApprovalStatus.MODIFIED
+        assert result.decision.modified_trades == modified_trades
+
+    @pytest.mark.asyncio
+    async def test_approve_not_found(self, manager):
+        """Test approving a non-existent request."""
+        result = await manager.approve(
+            approval_id="non-existent",
+            reviewer_id="reviewer-123",
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_cannot_approve_already_approved(
+        self, manager, sample_high_value_trades, sample_compliance_clean
+    ):
+        """Test that already approved requests can't be approved again."""
+        approval = await manager.create_approval_request(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_high_value_trades,
+            portfolio_value=100000.0,
+            compliance=sample_compliance_clean,
+        )
+
+        # First approval
+        await manager.approve(
+            approval_id=approval.approval_id,
+            reviewer_id="reviewer-1",
+        )
+
+        # Second approval attempt
+        result = await manager.approve(
+            approval_id=approval.approval_id,
+            reviewer_id="reviewer-2",
+        )
+
+        # Should return the approval but not change status
+        assert result is not None
+        assert result.status == ApprovalStatus.APPROVED
+        assert result.decision.reviewer_id == "reviewer-1"
+
+
+# ============================================================================
+# InMemoryApprovalPersistence Tests
+# ============================================================================
+
+
+class TestInMemoryApprovalPersistence:
+    """Tests for in-memory persistence."""
+
+    @pytest.fixture
+    def persistence(self):
+        """Create test persistence."""
+        return InMemoryApprovalPersistence()
+
+    @pytest.fixture
+    def sample_approval(self):
+        """Create sample approval."""
+        return ApprovalRequest(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            user_id="user-789",
+            trades=[{"symbol": "AAPL", "action": "buy"}],
+            compliance={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_save_and_get(self, persistence, sample_approval):
+        """Test saving and retrieving."""
+        await persistence.save(sample_approval)
+        retrieved = await persistence.get(sample_approval.approval_id)
+
+        assert retrieved is not None
+        assert retrieved.approval_id == sample_approval.approval_id
+
+    @pytest.mark.asyncio
+    async def test_get_by_workflow(self, persistence, sample_approval):
+        """Test retrieving by workflow ID."""
+        await persistence.save(sample_approval)
+        retrieved = await persistence.get_by_workflow(sample_approval.workflow_id)
+
+        assert retrieved is not None
+        assert retrieved.workflow_id == sample_approval.workflow_id
+
+    @pytest.mark.asyncio
+    async def test_list_pending(self, persistence):
+        """Test listing pending approvals."""
+        # Create approvals with different statuses
+        pending1 = ApprovalRequest(
+            workflow_id="wf-1",
+            trace_id="trace-1",
+            trades=[],
+            compliance={},
+            status=ApprovalStatus.PENDING,
+        )
+        pending2 = ApprovalRequest(
+            workflow_id="wf-2",
+            trace_id="trace-2",
+            trades=[],
+            compliance={},
+            status=ApprovalStatus.PENDING,
+        )
+        approved = ApprovalRequest(
+            workflow_id="wf-3",
+            trace_id="trace-3",
+            trades=[],
+            compliance={},
+            status=ApprovalStatus.APPROVED,
+        )
+
+        await persistence.save(pending1)
+        await persistence.save(pending2)
+        await persistence.save(approved)
+
+        pending = await persistence.list_pending()
+
+        assert len(pending) == 2
+        assert all(p.status == ApprovalStatus.PENDING for p in pending)
+
+    @pytest.mark.asyncio
+    async def test_expire_stale(self, persistence):
+        """Test expiring stale approvals."""
+        # Create an expired approval
+        expired = ApprovalRequest(
+            workflow_id="wf-expired",
+            trace_id="trace-expired",
+            trades=[],
+            compliance={},
+            status=ApprovalStatus.PENDING,
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+        # Create a valid approval
+        valid = ApprovalRequest(
+            workflow_id="wf-valid",
+            trace_id="trace-valid",
+            trades=[],
+            compliance={},
+            status=ApprovalStatus.PENDING,
+            expires_at=datetime.now(UTC) + timedelta(hours=24),
+        )
+
+        await persistence.save(expired)
+        await persistence.save(valid)
+
+        # Expire stale
+        expired_count = await persistence.expire_stale()
+
+        assert expired_count == 1
+
+        # Check that expired one is now expired status
+        retrieved_expired = await persistence.get(expired.approval_id)
+        assert retrieved_expired.status == ApprovalStatus.EXPIRED
+
+        # Check that valid one is still pending
+        retrieved_valid = await persistence.get(valid.approval_id)
+        assert retrieved_valid.status == ApprovalStatus.PENDING

--- a/tests/test_approval/test_models.py
+++ b/tests/test_approval/test_models.py
@@ -1,0 +1,309 @@
+"""Tests for approval models."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.approval.models import (
+    ApprovalConfig,
+    ApprovalDecision,
+    ApprovalRequest,
+    ApprovalStatus,
+    ApprovalTrigger,
+    RiskLevel,
+)
+
+
+# ============================================================================
+# ApprovalStatus Tests
+# ============================================================================
+
+
+class TestApprovalStatus:
+    """Tests for ApprovalStatus enum."""
+
+    def test_all_statuses_exist(self):
+        """Test that all expected statuses exist."""
+        assert ApprovalStatus.PENDING.value == "pending"
+        assert ApprovalStatus.APPROVED.value == "approved"
+        assert ApprovalStatus.REJECTED.value == "rejected"
+        assert ApprovalStatus.EXPIRED.value == "expired"
+        assert ApprovalStatus.MODIFIED.value == "modified"
+
+
+class TestRiskLevel:
+    """Tests for RiskLevel enum."""
+
+    def test_all_risk_levels_exist(self):
+        """Test that all expected risk levels exist."""
+        assert RiskLevel.LOW.value == "low"
+        assert RiskLevel.MEDIUM.value == "medium"
+        assert RiskLevel.HIGH.value == "high"
+        assert RiskLevel.CRITICAL.value == "critical"
+
+
+class TestApprovalTrigger:
+    """Tests for ApprovalTrigger enum."""
+
+    def test_all_triggers_exist(self):
+        """Test that all expected triggers exist."""
+        assert ApprovalTrigger.HIGH_VALUE_TRADE.value == "high_value_trade"
+        assert ApprovalTrigger.HIGH_CONCENTRATION.value == "high_concentration"
+        assert ApprovalTrigger.HIGH_RISK_ASSET.value == "high_risk_asset"
+        assert ApprovalTrigger.FIRST_TIME_SYMBOL.value == "first_time_symbol"
+        assert ApprovalTrigger.LOW_CONFIDENCE.value == "low_confidence"
+        assert ApprovalTrigger.COMPLIANCE_WARNING.value == "compliance_warning"
+
+
+# ============================================================================
+# ApprovalDecision Tests
+# ============================================================================
+
+
+class TestApprovalDecision:
+    """Tests for ApprovalDecision model."""
+
+    def test_create_approval_decision(self):
+        """Test creating an approval decision."""
+        decision = ApprovalDecision(
+            status=ApprovalStatus.APPROVED,
+            reviewer_id="reviewer-123",
+            reason="Looks good",
+        )
+        assert decision.status == ApprovalStatus.APPROVED
+        assert decision.reviewer_id == "reviewer-123"
+        assert decision.reason == "Looks good"
+        assert decision.modified_trades is None
+        assert decision.decided_at is not None
+
+    def test_create_rejection_decision(self):
+        """Test creating a rejection decision."""
+        decision = ApprovalDecision(
+            status=ApprovalStatus.REJECTED,
+            reviewer_id="reviewer-456",
+            reason="Trade value too high",
+        )
+        assert decision.status == ApprovalStatus.REJECTED
+        assert decision.reason == "Trade value too high"
+
+    def test_create_modified_decision(self):
+        """Test creating a modified decision."""
+        modified_trades = [{"symbol": "AAPL", "action": "buy", "quantity": 50}]
+        decision = ApprovalDecision(
+            status=ApprovalStatus.MODIFIED,
+            reviewer_id="reviewer-789",
+            reason="Reduced quantity",
+            modified_trades=modified_trades,
+        )
+        assert decision.status == ApprovalStatus.MODIFIED
+        assert decision.modified_trades == modified_trades
+
+
+# ============================================================================
+# ApprovalRequest Tests
+# ============================================================================
+
+
+class TestApprovalRequest:
+    """Tests for ApprovalRequest model."""
+
+    @pytest.fixture
+    def sample_trades(self):
+        """Sample trades for testing."""
+        return [
+            {
+                "symbol": "AAPL",
+                "action": "buy",
+                "quantity": 100,
+                "estimated_value": 15000.0,
+            },
+            {
+                "symbol": "GOOGL",
+                "action": "sell",
+                "quantity": 50,
+                "estimated_value": 10000.0,
+            },
+        ]
+
+    @pytest.fixture
+    def sample_compliance(self):
+        """Sample compliance data for testing."""
+        return {
+            "is_compliant": True,
+            "violations": [],
+            "warnings": ["High concentration in tech sector"],
+            "requires_approval": True,
+        }
+
+    def test_create_approval_request(self, sample_trades, sample_compliance):
+        """Test creating an approval request."""
+        request = ApprovalRequest(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            user_id="user-789",
+            risk_level=RiskLevel.HIGH,
+            triggers=[ApprovalTrigger.HIGH_VALUE_TRADE],
+            trades=sample_trades,
+            total_value=25000.0,
+            portfolio_value=100000.0,
+            compliance=sample_compliance,
+            summary="Buy AAPL, sell GOOGL",
+        )
+
+        assert request.approval_id is not None
+        assert request.workflow_id == "wf-123"
+        assert request.trace_id == "trace-456"
+        assert request.user_id == "user-789"
+        assert request.status == ApprovalStatus.PENDING
+        assert request.risk_level == RiskLevel.HIGH
+        assert len(request.triggers) == 1
+        assert len(request.trades) == 2
+        assert request.total_value == 25000.0
+        assert request.decision is None
+
+    def test_is_pending(self, sample_trades, sample_compliance):
+        """Test is_pending method."""
+        request = ApprovalRequest(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_trades,
+            compliance=sample_compliance,
+        )
+        assert request.is_pending() is True
+
+        request.status = ApprovalStatus.APPROVED
+        assert request.is_pending() is False
+
+    def test_is_expired_without_expiry(self, sample_trades, sample_compliance):
+        """Test is_expired when no expiry is set."""
+        request = ApprovalRequest(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_trades,
+            compliance=sample_compliance,
+        )
+        assert request.is_expired() is False
+
+    def test_is_expired_with_future_expiry(self, sample_trades, sample_compliance):
+        """Test is_expired with future expiry."""
+        request = ApprovalRequest(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_trades,
+            compliance=sample_compliance,
+            expires_at=datetime.now(UTC) + timedelta(hours=24),
+        )
+        assert request.is_expired() is False
+
+    def test_is_expired_with_past_expiry(self, sample_trades, sample_compliance):
+        """Test is_expired with past expiry."""
+        request = ApprovalRequest(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_trades,
+            compliance=sample_compliance,
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+        assert request.is_expired() is True
+
+    def test_approve(self, sample_trades, sample_compliance):
+        """Test approve method."""
+        request = ApprovalRequest(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_trades,
+            compliance=sample_compliance,
+        )
+
+        request.approve(reviewer_id="reviewer-123", reason="Approved")
+
+        assert request.status == ApprovalStatus.APPROVED
+        assert request.decision is not None
+        assert request.decision.reviewer_id == "reviewer-123"
+        assert request.decision.reason == "Approved"
+
+    def test_reject(self, sample_trades, sample_compliance):
+        """Test reject method."""
+        request = ApprovalRequest(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_trades,
+            compliance=sample_compliance,
+        )
+
+        request.reject(reviewer_id="reviewer-456", reason="Too risky")
+
+        assert request.status == ApprovalStatus.REJECTED
+        assert request.decision is not None
+        assert request.decision.reviewer_id == "reviewer-456"
+        assert request.decision.reason == "Too risky"
+
+    def test_modify(self, sample_trades, sample_compliance):
+        """Test modify method."""
+        request = ApprovalRequest(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_trades,
+            compliance=sample_compliance,
+        )
+
+        modified_trades = [{"symbol": "AAPL", "action": "buy", "quantity": 50}]
+        request.modify(
+            reviewer_id="reviewer-789",
+            modified_trades=modified_trades,
+            reason="Reduced quantity",
+        )
+
+        assert request.status == ApprovalStatus.MODIFIED
+        assert request.decision is not None
+        assert request.decision.modified_trades == modified_trades
+
+    def test_mark_expired(self, sample_trades, sample_compliance):
+        """Test mark_expired method."""
+        request = ApprovalRequest(
+            workflow_id="wf-123",
+            trace_id="trace-456",
+            trades=sample_trades,
+            compliance=sample_compliance,
+        )
+
+        request.mark_expired()
+
+        assert request.status == ApprovalStatus.EXPIRED
+
+
+# ============================================================================
+# ApprovalConfig Tests
+# ============================================================================
+
+
+class TestApprovalConfig:
+    """Tests for ApprovalConfig model."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = ApprovalConfig()
+
+        assert config.high_value_threshold == 10000.0
+        assert config.critical_value_threshold == 50000.0
+        assert config.concentration_threshold == 0.20
+        assert config.critical_concentration_threshold == 0.30
+        assert config.low_confidence_threshold == 0.7
+        assert "options" in config.high_risk_asset_types
+        assert config.default_timeout_hours == 24
+        assert config.critical_timeout_hours == 4
+        assert config.auto_approve_low_risk is True
+
+    def test_custom_config(self):
+        """Test custom configuration values."""
+        config = ApprovalConfig(
+            high_value_threshold=5000.0,
+            concentration_threshold=0.15,
+            default_timeout_hours=12,
+            auto_approve_low_risk=False,
+        )
+
+        assert config.high_value_threshold == 5000.0
+        assert config.concentration_threshold == 0.15
+        assert config.default_timeout_hours == 12
+        assert config.auto_approve_low_risk is False


### PR DESCRIPTION
## Summary
- Implement approval workflows for high-risk recommendations
- Enable human oversight before trade execution
- Add configurable approval triggers and thresholds

## Changes

### New Files
- `src/approval/` - Approval workflow module
  - `models.py` - ApprovalRequest, ApprovalStatus, RiskLevel, ApprovalTrigger
  - `manager.py` - ApprovalManager, persistence classes
- `src/api/approvals.py` - API endpoints for approval management
- `tests/test_approval/` - Comprehensive test suite (54 tests)

### Modified Files
- `src/api/routes.py` - Integration with /analyze endpoint

## Approval Triggers
- Trade value exceeds threshold (default >$10,000)
- Portfolio concentration >20% in single position
- High-risk asset classes (leveraged ETFs, etc.)
- First-time recommendations for new symbols
- Confidence score below threshold
- Compliance warnings or violations

## API Endpoints
```
GET  /approvals              # List pending approvals
GET  /approvals/{id}         # Get approval details
POST /approvals/{id}/approve # Approve with optional reason
POST /approvals/{id}/reject  # Reject with required reason
POST /approvals/{id}/modify  # Approve with modified trades
```

## Test plan
- [x] Unit tests for approval models (ApprovalRequest, ApprovalStatus, etc.)
- [x] Unit tests for ApprovalManager evaluation logic
- [x] Unit tests for approval decisions (approve/reject/modify)
- [x] Unit tests for persistence (InMemoryApprovalPersistence)
- [x] API integration tests for all endpoints
- [x] All 1265 tests pass (including 54 new tests)
- [x] Linting and type checking pass

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)