### PR TITLE
feat: Add real market data integration with Polygon.io API (#76)

### DIFF
--- a/src/cache/manager.py
+++ b/src/cache/manager.py
@@ -33,6 +33,10 @@ class CacheType(Enum):
     NEWS = "news"
     ANALYSIS = "analysis"
     RECOMMENDATION = "recommendation"
+    # New types for Polygon.io integration
+    QUOTE = "quote"
+    DAILY_BARS = "daily_bars"
+    COMPANY_INFO = "company_info"
 
 
 @dataclass
@@ -41,16 +45,22 @@ class CacheConfig:
 
     Attributes:
         market_data_ttl: TTL for market data in seconds (default: 5 min).
-        news_ttl: TTL for news data in seconds (default: 1 hour).
+        news_ttl: TTL for news data in seconds (default: 15 min for Polygon).
         analysis_ttl: TTL for analysis results in seconds (default: 24 hours).
         recommendation_ttl: TTL for recommendations in seconds (default: 1 hour).
+        quote_ttl: TTL for real-time quotes in seconds (default: 1 min).
+        daily_bars_ttl: TTL for daily bars in seconds (default: 1 hour).
+        company_info_ttl: TTL for company info in seconds (default: 24 hours).
         default_ttl: Default TTL for unspecified types (default: 5 min).
     """
 
     market_data_ttl: int = 300  # 5 minutes
-    news_ttl: int = 3600  # 1 hour
+    news_ttl: int = 900  # 15 minutes (optimized for Polygon rate limits)
     analysis_ttl: int = 86400  # 24 hours
     recommendation_ttl: int = 3600  # 1 hour
+    quote_ttl: int = 60  # 1 minute (real-time quotes)
+    daily_bars_ttl: int = 3600  # 1 hour
+    company_info_ttl: int = 86400  # 24 hours
     default_ttl: int = 300  # 5 minutes
 
     def get_ttl(self, cache_type: CacheType) -> int:
@@ -60,6 +70,9 @@ class CacheConfig:
             CacheType.NEWS: self.news_ttl,
             CacheType.ANALYSIS: self.analysis_ttl,
             CacheType.RECOMMENDATION: self.recommendation_ttl,
+            CacheType.QUOTE: self.quote_ttl,
+            CacheType.DAILY_BARS: self.daily_bars_ttl,
+            CacheType.COMPANY_INFO: self.company_info_ttl,
         }
         return ttl_map.get(cache_type, self.default_ttl)
 

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,20 @@
+"""Data layer for market data integration.
+
+This module provides:
+- PolygonClient: Async client for Polygon.io API
+- DataSourceRouter: Fallback chain orchestration
+- Data models: Quote, Bar, CompanyInfo, NewsArticle
+"""
+
+from src.data.models import Bar, CompanyInfo, NewsArticle, Quote
+from src.data.polygon import PolygonClient
+from src.data.router import DataSourceRouter
+
+__all__ = [
+    "Bar",
+    "CompanyInfo",
+    "DataSourceRouter",
+    "NewsArticle",
+    "PolygonClient",
+    "Quote",
+]

--- a/src/data/models.py
+++ b/src/data/models.py
@@ -1,0 +1,162 @@
+"""Data models for market data integration.
+
+This module defines the Pydantic models used across data sources
+(Polygon.io, Yahoo Finance) and the caching layer.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class DataSource(str, Enum):
+    """Source of market data."""
+
+    POLYGON = "polygon"
+    YAHOO = "yahoo"
+    CACHE = "cache"
+    MOCK = "mock"
+
+
+class Quote(BaseModel):
+    """Real-time quote data for a symbol.
+
+    Attributes:
+        symbol: Stock ticker symbol.
+        price: Current/last price.
+        change_percent: Percentage change from previous close.
+        volume: Trading volume.
+        open: Opening price.
+        high: Day high.
+        low: Day low.
+        previous_close: Previous day's close.
+        timestamp: When the quote was fetched.
+        source: Data source (polygon, yahoo, cache, mock).
+    """
+
+    symbol: str
+    price: float
+    change_percent: float
+    volume: int
+    open: float | None = None
+    high: float | None = None
+    low: float | None = None
+    previous_close: float | None = None
+    timestamp: datetime = Field(default_factory=datetime.now)
+    source: DataSource = DataSource.POLYGON
+
+
+class Bar(BaseModel):
+    """OHLCV bar data for a time period.
+
+    Attributes:
+        symbol: Stock ticker symbol.
+        open: Opening price.
+        high: High price.
+        low: Low price.
+        close: Closing price.
+        volume: Trading volume.
+        vwap: Volume-weighted average price.
+        timestamp: Bar timestamp.
+        transactions: Number of transactions (if available).
+    """
+
+    symbol: str
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: int
+    vwap: float | None = None
+    timestamp: datetime
+    transactions: int | None = None
+
+
+class CompanyInfo(BaseModel):
+    """Company reference data.
+
+    Attributes:
+        symbol: Stock ticker symbol.
+        name: Company name.
+        description: Company description.
+        sector: Industry sector.
+        industry: Specific industry.
+        market_cap: Market capitalization.
+        employees: Number of employees.
+        website: Company website URL.
+        exchange: Stock exchange (e.g., NASDAQ, NYSE).
+        currency: Trading currency.
+        timestamp: When the data was fetched.
+        source: Data source.
+    """
+
+    symbol: str
+    name: str
+    description: str | None = None
+    sector: str | None = None
+    industry: str | None = None
+    market_cap: float | None = None
+    employees: int | None = None
+    website: str | None = None
+    exchange: str | None = None
+    currency: str = "USD"
+    timestamp: datetime = Field(default_factory=datetime.now)
+    source: DataSource = DataSource.POLYGON
+
+
+class NewsArticle(BaseModel):
+    """News article related to a symbol or market.
+
+    Attributes:
+        id: Unique article identifier.
+        title: Article title.
+        author: Article author.
+        publisher: Publishing source.
+        url: Article URL.
+        summary: Article summary/description.
+        symbols: Related stock symbols.
+        sentiment: Sentiment analysis (positive, negative, neutral).
+        published_at: Publication timestamp.
+        source: Data source.
+    """
+
+    id: str
+    title: str
+    author: str | None = None
+    publisher: str
+    url: str
+    summary: str | None = None
+    symbols: list[str] = Field(default_factory=list)
+    sentiment: Literal["positive", "negative", "neutral"] | None = None
+    published_at: datetime
+    source: DataSource = DataSource.POLYGON
+
+
+class MarketDataResult(BaseModel):
+    """Unified result from any data source.
+
+    Used by DataSourceRouter to return consistent data regardless of source.
+
+    Attributes:
+        symbol: Stock ticker symbol.
+        quote: Quote data (if requested).
+        bars: Historical bar data (if requested).
+        company_info: Company reference data (if requested).
+        news: Related news articles (if requested).
+        source: Which source provided the data.
+        cached: Whether this came from cache.
+        fallback_used: Whether a fallback source was used.
+        errors: Any errors encountered during fetch.
+    """
+
+    symbol: str
+    quote: Quote | None = None
+    bars: list[Bar] | None = None
+    company_info: CompanyInfo | None = None
+    news: list[NewsArticle] | None = None
+    source: DataSource = DataSource.POLYGON
+    cached: bool = False
+    fallback_used: bool = False
+    errors: list[str] = Field(default_factory=list)

--- a/src/data/polygon.py
+++ b/src/data/polygon.py
@@ -1,0 +1,341 @@
+"""Polygon.io API client for market data.
+
+This module provides an async client for the Polygon.io REST API
+with support for quotes, historical bars, company info, and news.
+"""
+
+import os
+from datetime import datetime, timedelta
+from typing import Any
+
+import httpx
+import structlog
+
+from src.data.models import Bar, CompanyInfo, DataSource, NewsArticle, Quote
+
+logger = structlog.get_logger(__name__)
+
+
+class PolygonError(Exception):
+    """Base exception for Polygon API errors."""
+
+    pass
+
+
+class PolygonAuthError(PolygonError):
+    """Raised when API key is invalid or missing."""
+
+    pass
+
+
+class PolygonRateLimitError(PolygonError):
+    """Raised when rate limit is exceeded (HTTP 429)."""
+
+    def __init__(self, retry_after: float | None = None):
+        self.retry_after = retry_after
+        super().__init__(f"Rate limit exceeded. Retry after {retry_after}s")
+
+
+class PolygonAPIError(PolygonError):
+    """Raised for general API errors."""
+
+    def __init__(self, status: int, message: str):
+        self.status = status
+        self.message = message
+        super().__init__(f"Polygon API error {status}: {message}")
+
+
+class PolygonClient:
+    """Async client for Polygon.io REST API.
+
+    Provides methods to fetch:
+    - Real-time quotes
+    - Historical OHLCV bars
+    - Company reference data
+    - Market news
+
+    Example:
+        client = PolygonClient()
+        quote = await client.get_quote("AAPL")
+        print(f"AAPL: ${quote.price}")
+    """
+
+    BASE_URL = "https://api.polygon.io"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        """Initialize the Polygon client.
+
+        Args:
+            api_key: Polygon.io API key. If not provided, reads from
+                POLYGON_API_KEY environment variable.
+        """
+        self.api_key = api_key or os.environ.get("POLYGON_API_KEY")
+        self._client: httpx.AsyncClient | None = None
+        self._logger = logger.bind(component="polygon_client")
+
+    @property
+    def is_configured(self) -> bool:
+        """Check if API key is configured."""
+        return bool(self.api_key)
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Get or create httpx client."""
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                timeout=30.0,
+            )
+        return self._client
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    async def _request(self, endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Make an authenticated request to Polygon API.
+
+        Args:
+            endpoint: API endpoint (e.g., "/v2/aggs/ticker/AAPL/prev").
+            params: Optional query parameters.
+
+        Returns:
+            JSON response data.
+
+        Raises:
+            PolygonAuthError: If API key is missing or invalid.
+            PolygonRateLimitError: If rate limit is exceeded.
+            PolygonAPIError: For other API errors.
+        """
+        if not self.api_key:
+            raise PolygonAuthError("POLYGON_API_KEY not configured")
+
+        client = await self._get_client()
+        url = f"{self.BASE_URL}{endpoint}"
+
+        self._logger.debug("polygon_request", endpoint=endpoint, params=params)
+
+        try:
+            response = await client.get(url, params=params)
+
+            if response.status_code == 401:
+                raise PolygonAuthError("Invalid API key")
+
+            if response.status_code == 429:
+                retry_after = response.headers.get("Retry-After")
+                raise PolygonRateLimitError(
+                    retry_after=float(retry_after) if retry_after else 12.0
+                )
+
+            if response.status_code != 200:
+                raise PolygonAPIError(response.status_code, response.text)
+
+            data = response.json()
+            self._logger.debug(
+                "polygon_response",
+                endpoint=endpoint,
+                status=response.status_code,
+            )
+            return data
+
+        except httpx.RequestError as e:
+            self._logger.error("polygon_client_error", error=str(e))
+            raise PolygonAPIError(0, str(e)) from e
+
+    async def get_quote(self, symbol: str) -> Quote:
+        """Get the previous day's OHLCV for a symbol.
+
+        Uses the /v2/aggs/ticker/{symbol}/prev endpoint.
+
+        Args:
+            symbol: Stock ticker symbol (e.g., "AAPL").
+
+        Returns:
+            Quote with price and volume data.
+
+        Raises:
+            PolygonError: If the request fails.
+            ValueError: If symbol data is not available.
+        """
+        symbol = symbol.upper()
+        endpoint = f"/v2/aggs/ticker/{symbol}/prev"
+
+        data = await self._request(endpoint)
+
+        if data.get("resultsCount", 0) == 0:
+            raise ValueError(f"No data available for symbol: {symbol}")
+
+        result = data["results"][0]
+
+        # Calculate change percent from open to close
+        open_price = result.get("o", 0)
+        close_price = result.get("c", 0)
+        if open_price > 0:
+            change_percent = ((close_price - open_price) / open_price) * 100
+        else:
+            change_percent = 0.0
+
+        return Quote(
+            symbol=symbol,
+            price=close_price,
+            change_percent=round(change_percent, 2),
+            volume=int(result.get("v", 0)),
+            open=result.get("o"),
+            high=result.get("h"),
+            low=result.get("l"),
+            previous_close=result.get("c"),
+            timestamp=datetime.fromtimestamp(result.get("t", 0) / 1000),
+            source=DataSource.POLYGON,
+        )
+
+    async def get_bars(
+        self,
+        symbol: str,
+        timeframe: str = "day",
+        limit: int = 30,
+    ) -> list[Bar]:
+        """Get historical OHLCV bars for a symbol.
+
+        Uses the /v2/aggs/ticker/{symbol}/range endpoint.
+
+        Args:
+            symbol: Stock ticker symbol.
+            timeframe: Bar timeframe ("day", "week", "month").
+            limit: Number of bars to fetch (max 50000).
+
+        Returns:
+            List of Bar objects.
+        """
+        symbol = symbol.upper()
+
+        # Map timeframe to Polygon format
+        timeframe_map = {
+            "day": ("1", "day"),
+            "week": ("1", "week"),
+            "month": ("1", "month"),
+        }
+        multiplier, timespan = timeframe_map.get(timeframe, ("1", "day"))
+
+        # Calculate date range
+        end_date = datetime.now()
+        if timeframe == "day":
+            start_date = end_date - timedelta(days=limit)
+        elif timeframe == "week":
+            start_date = end_date - timedelta(weeks=limit)
+        else:
+            start_date = end_date - timedelta(days=limit * 30)
+
+        endpoint = f"/v2/aggs/ticker/{symbol}/range/{multiplier}/{timespan}/{start_date.strftime('%Y-%m-%d')}/{end_date.strftime('%Y-%m-%d')}"
+
+        data = await self._request(endpoint, params={"limit": limit, "sort": "desc"})
+
+        bars = []
+        for result in data.get("results", []):
+            bars.append(
+                Bar(
+                    symbol=symbol,
+                    open=result["o"],
+                    high=result["h"],
+                    low=result["l"],
+                    close=result["c"],
+                    volume=int(result["v"]),
+                    vwap=result.get("vw"),
+                    timestamp=datetime.fromtimestamp(result["t"] / 1000),
+                    transactions=result.get("n"),
+                )
+            )
+
+        return bars
+
+    async def get_company_info(self, symbol: str) -> CompanyInfo:
+        """Get company reference data.
+
+        Uses the /v3/reference/tickers/{symbol} endpoint.
+
+        Args:
+            symbol: Stock ticker symbol.
+
+        Returns:
+            CompanyInfo with company details.
+        """
+        symbol = symbol.upper()
+        endpoint = f"/v3/reference/tickers/{symbol}"
+
+        data = await self._request(endpoint)
+
+        if data.get("status") != "OK" or "results" not in data:
+            raise ValueError(f"Company info not available for: {symbol}")
+
+        result = data["results"]
+
+        return CompanyInfo(
+            symbol=symbol,
+            name=result.get("name", symbol),
+            description=result.get("description"),
+            sector=result.get("sic_description"),
+            industry=result.get("sic_description"),
+            market_cap=result.get("market_cap"),
+            employees=result.get("total_employees"),
+            website=result.get("homepage_url"),
+            exchange=result.get("primary_exchange"),
+            currency=result.get("currency_name", "USD"),
+            source=DataSource.POLYGON,
+        )
+
+    async def search_news(
+        self,
+        symbol: str | None = None,
+        limit: int = 10,
+    ) -> list[NewsArticle]:
+        """Search for market news.
+
+        Uses the /v2/reference/news endpoint.
+
+        Args:
+            symbol: Optional stock symbol to filter news.
+            limit: Maximum number of articles (default 10).
+
+        Returns:
+            List of NewsArticle objects.
+        """
+        endpoint = "/v2/reference/news"
+        params: dict[str, Any] = {"limit": limit, "order": "desc"}
+
+        if symbol:
+            params["ticker"] = symbol.upper()
+
+        data = await self._request(endpoint, params=params)
+
+        articles = []
+        for result in data.get("results", []):
+            # Parse published timestamp
+            published_str = result.get("published_utc", "")
+            try:
+                published_at = datetime.fromisoformat(published_str.replace("Z", "+00:00"))
+            except (ValueError, AttributeError):
+                published_at = datetime.now()
+
+            articles.append(
+                NewsArticle(
+                    id=result.get("id", ""),
+                    title=result.get("title", ""),
+                    author=result.get("author"),
+                    publisher=result.get("publisher", {}).get("name", "Unknown"),
+                    url=result.get("article_url", ""),
+                    summary=result.get("description"),
+                    symbols=result.get("tickers", []),
+                    published_at=published_at,
+                    source=DataSource.POLYGON,
+                )
+            )
+
+        return articles
+
+    async def __aenter__(self) -> "PolygonClient":
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Async context manager exit."""
+        await self.close()

--- a/src/data/router.py
+++ b/src/data/router.py
@@ -1,0 +1,572 @@
+"""Data source routing with fallback chain and rate limiting.
+
+This module provides:
+- RateLimitedQueue: Request queue that respects rate limits
+- DataSourceRouter: Orchestrates the fallback chain (Polygon → Yahoo → Cache → Mock)
+"""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import Any, TypeVar
+
+import structlog
+
+from src.cache.manager import CacheKeyBuilder, CacheManager, CacheType
+from src.data.models import (
+    Bar,
+    CompanyInfo,
+    DataSource,
+    MarketDataResult,
+    NewsArticle,
+    Quote,
+)
+from src.data.polygon import (
+    PolygonAPIError,
+    PolygonAuthError,
+    PolygonClient,
+    PolygonRateLimitError,
+)
+
+logger = structlog.get_logger(__name__)
+
+T = TypeVar("T")
+
+
+class RateLimitedQueue:
+    """Queue that delays requests to respect rate limits.
+
+    Uses a semaphore-based approach where tokens are released
+    after a fixed interval to maintain the request rate.
+
+    Example:
+        queue = RateLimitedQueue(rate_limit=5)  # 5 req/min
+
+        # This will wait if rate limit is reached
+        result = await queue.submit(fetch_data())
+    """
+
+    def __init__(self, rate_limit: int = 5, window_seconds: int = 60) -> None:
+        """Initialize the rate-limited queue.
+
+        Args:
+            rate_limit: Maximum requests per window.
+            window_seconds: Time window in seconds.
+        """
+        self._rate_limit = rate_limit
+        self._window_seconds = window_seconds
+        self._refill_interval = window_seconds / rate_limit
+        self._semaphore = asyncio.Semaphore(rate_limit)
+        self._logger = logger.bind(component="rate_limited_queue")
+        self._pending_count = 0
+
+    @property
+    def refill_interval(self) -> float:
+        """Seconds between token refills."""
+        return self._refill_interval
+
+    @property
+    def pending_requests(self) -> int:
+        """Number of requests waiting in queue."""
+        return self._pending_count
+
+    async def submit(self, coro: Awaitable[T]) -> T:
+        """Submit a request to the rate-limited queue.
+
+        Waits for an available slot before executing the coroutine.
+        Releases the slot after the refill interval.
+
+        Args:
+            coro: Coroutine to execute.
+
+        Returns:
+            Result of the coroutine.
+        """
+        self._pending_count += 1
+        self._logger.debug(
+            "queue_submit",
+            pending=self._pending_count,
+            refill_interval=self._refill_interval,
+        )
+
+        await self._semaphore.acquire()
+        self._pending_count -= 1
+
+        try:
+            result = await coro
+            return result
+        finally:
+            # Schedule token release after refill interval
+            asyncio.get_event_loop().call_later(
+                self._refill_interval,
+                self._semaphore.release,
+            )
+
+    def reset(self) -> None:
+        """Reset the queue (for testing)."""
+        self._semaphore = asyncio.Semaphore(self._rate_limit)
+        self._pending_count = 0
+
+
+class DataSourceRouter:
+    """Routes data requests through the fallback chain.
+
+    Fallback order: Polygon → Yahoo → Cache → Mock
+
+    Handles:
+    - Rate limiting for Polygon API
+    - Automatic fallback on errors
+    - Caching of successful responses
+    - Metrics and logging
+
+    Example:
+        router = DataSourceRouter(polygon_client, cache_manager)
+        result = await router.get_quote("AAPL")
+        print(f"Price: {result.quote.price} (source: {result.source})")
+    """
+
+    # Cache TTLs matching the design
+    QUOTE_TTL = 60  # 1 minute
+    BARS_TTL = 3600  # 1 hour
+    COMPANY_INFO_TTL = 86400  # 24 hours
+    NEWS_TTL = 900  # 15 minutes
+
+    def __init__(
+        self,
+        polygon: PolygonClient | None = None,
+        cache: CacheManager | None = None,
+        rate_limit: int = 5,
+    ) -> None:
+        """Initialize the data source router.
+
+        Args:
+            polygon: Polygon.io client instance.
+            cache: Cache manager instance.
+            rate_limit: Polygon API rate limit (requests per minute).
+        """
+        self._polygon = polygon or PolygonClient()
+        self._cache = cache
+        self._queue = RateLimitedQueue(rate_limit=rate_limit)
+        self._logger = logger.bind(component="data_source_router")
+
+        # Track fallback stats
+        self._stats = {
+            "polygon_success": 0,
+            "polygon_rate_limited": 0,
+            "yahoo_fallback": 0,
+            "cache_fallback": 0,
+            "mock_fallback": 0,
+        }
+
+    @property
+    def stats(self) -> dict[str, int]:
+        """Get fallback statistics."""
+        return self._stats.copy()
+
+    def reset_stats(self) -> None:
+        """Reset fallback statistics."""
+        for key in self._stats:
+            self._stats[key] = 0
+
+    async def get_quote(self, symbol: str) -> MarketDataResult:
+        """Get quote with full fallback chain.
+
+        Args:
+            symbol: Stock ticker symbol.
+
+        Returns:
+            MarketDataResult with quote data.
+        """
+        symbol = symbol.upper()
+        result = MarketDataResult(symbol=symbol)
+
+        # Try Polygon first (through rate-limited queue)
+        try:
+            if self._polygon.is_configured:
+                quote = await self._queue.submit(self._polygon.get_quote(symbol))
+                result.quote = quote
+                result.source = DataSource.POLYGON
+                self._stats["polygon_success"] += 1
+
+                # Cache the result
+                if self._cache:
+                    cache_key = CacheKeyBuilder.market_data(symbol, "quote")
+                    await self._cache.set(
+                        cache_key,
+                        quote.model_dump(mode="json"),
+                        ttl=self.QUOTE_TTL,
+                    )
+
+                self._logger.info("quote_fetched", symbol=symbol, source="polygon")
+                return result
+
+        except PolygonRateLimitError:
+            self._stats["polygon_rate_limited"] += 1
+            self._logger.warning("polygon_rate_limited", symbol=symbol)
+            result.errors.append("Polygon rate limited")
+
+        except (PolygonAuthError, PolygonAPIError) as e:
+            self._logger.warning("polygon_error", symbol=symbol, error=str(e))
+            result.errors.append(f"Polygon error: {e}")
+
+        except Exception as e:
+            self._logger.error("polygon_unexpected_error", symbol=symbol, error=str(e))
+            result.errors.append(f"Unexpected error: {e}")
+
+        # Try Yahoo fallback
+        try:
+            quote = await self._fetch_yahoo_quote(symbol)
+            if quote:
+                result.quote = quote
+                result.source = DataSource.YAHOO
+                result.fallback_used = True
+                self._stats["yahoo_fallback"] += 1
+
+                # Cache the result
+                if self._cache:
+                    cache_key = CacheKeyBuilder.market_data(symbol, "quote")
+                    await self._cache.set(
+                        cache_key,
+                        quote.model_dump(mode="json"),
+                        ttl=self.QUOTE_TTL,
+                    )
+
+                self._logger.info("quote_fetched", symbol=symbol, source="yahoo")
+                return result
+
+        except Exception as e:
+            self._logger.warning("yahoo_error", symbol=symbol, error=str(e))
+            result.errors.append(f"Yahoo error: {e}")
+
+        # Try cache fallback
+        if self._cache:
+            try:
+                cache_key = CacheKeyBuilder.market_data(symbol, "quote")
+                cached = await self._cache.get(cache_key)
+                if cached:
+                    result.quote = Quote(**cached)
+                    result.source = DataSource.CACHE
+                    result.cached = True
+                    result.fallback_used = True
+                    self._stats["cache_fallback"] += 1
+                    self._logger.info("quote_fetched", symbol=symbol, source="cache")
+                    return result
+
+            except Exception as e:
+                self._logger.warning("cache_error", symbol=symbol, error=str(e))
+                result.errors.append(f"Cache error: {e}")
+
+        # Mock fallback (last resort)
+        result.quote = self._get_mock_quote(symbol)
+        result.source = DataSource.MOCK
+        result.fallback_used = True
+        self._stats["mock_fallback"] += 1
+        self._logger.info("quote_fetched", symbol=symbol, source="mock")
+        return result
+
+    async def get_bars(
+        self,
+        symbol: str,
+        timeframe: str = "day",
+        limit: int = 30,
+    ) -> MarketDataResult:
+        """Get historical bars with fallback chain.
+
+        Args:
+            symbol: Stock ticker symbol.
+            timeframe: Bar timeframe ("day", "week", "month").
+            limit: Number of bars to fetch.
+
+        Returns:
+            MarketDataResult with bars data.
+        """
+        symbol = symbol.upper()
+        result = MarketDataResult(symbol=symbol)
+        cache_key = CacheKeyBuilder.market_data(symbol, f"bars_{timeframe}")
+
+        # Try Polygon
+        try:
+            if self._polygon.is_configured:
+                bars = await self._queue.submit(
+                    self._polygon.get_bars(symbol, timeframe, limit)
+                )
+                result.bars = bars
+                result.source = DataSource.POLYGON
+                self._stats["polygon_success"] += 1
+
+                if self._cache:
+                    await self._cache.set(
+                        cache_key,
+                        [b.model_dump(mode="json") for b in bars],
+                        ttl=self.BARS_TTL,
+                    )
+
+                return result
+
+        except (PolygonRateLimitError, PolygonAuthError, PolygonAPIError) as e:
+            self._logger.warning("polygon_bars_error", symbol=symbol, error=str(e))
+            result.errors.append(str(e))
+
+        # Try cache
+        if self._cache:
+            cached = await self._cache.get(cache_key)
+            if cached:
+                result.bars = [Bar(**b) for b in cached]
+                result.source = DataSource.CACHE
+                result.cached = True
+                result.fallback_used = True
+                self._stats["cache_fallback"] += 1
+                return result
+
+        # Mock fallback
+        result.bars = self._get_mock_bars(symbol, limit)
+        result.source = DataSource.MOCK
+        result.fallback_used = True
+        self._stats["mock_fallback"] += 1
+        return result
+
+    async def get_company_info(self, symbol: str) -> MarketDataResult:
+        """Get company info with fallback chain.
+
+        Args:
+            symbol: Stock ticker symbol.
+
+        Returns:
+            MarketDataResult with company info.
+        """
+        symbol = symbol.upper()
+        result = MarketDataResult(symbol=symbol)
+        cache_key = CacheKeyBuilder.custom("company", symbol)
+
+        # Try Polygon
+        try:
+            if self._polygon.is_configured:
+                info = await self._queue.submit(self._polygon.get_company_info(symbol))
+                result.company_info = info
+                result.source = DataSource.POLYGON
+                self._stats["polygon_success"] += 1
+
+                if self._cache:
+                    await self._cache.set(
+                        cache_key,
+                        info.model_dump(mode="json"),
+                        ttl=self.COMPANY_INFO_TTL,
+                    )
+
+                return result
+
+        except (PolygonRateLimitError, PolygonAuthError, PolygonAPIError) as e:
+            self._logger.warning("polygon_company_error", symbol=symbol, error=str(e))
+            result.errors.append(str(e))
+
+        # Try cache
+        if self._cache:
+            cached = await self._cache.get(cache_key)
+            if cached:
+                result.company_info = CompanyInfo(**cached)
+                result.source = DataSource.CACHE
+                result.cached = True
+                result.fallback_used = True
+                self._stats["cache_fallback"] += 1
+                return result
+
+        # Mock fallback
+        result.company_info = self._get_mock_company_info(symbol)
+        result.source = DataSource.MOCK
+        result.fallback_used = True
+        self._stats["mock_fallback"] += 1
+        return result
+
+    async def search_news(
+        self,
+        symbol: str | None = None,
+        limit: int = 10,
+    ) -> MarketDataResult:
+        """Search news with fallback chain.
+
+        Args:
+            symbol: Optional stock symbol to filter news.
+            limit: Maximum number of articles.
+
+        Returns:
+            MarketDataResult with news articles.
+        """
+        result = MarketDataResult(symbol=symbol or "MARKET")
+        cache_key = CacheKeyBuilder.custom("news", symbol or "market")
+
+        # Try Polygon
+        try:
+            if self._polygon.is_configured:
+                articles = await self._queue.submit(
+                    self._polygon.search_news(symbol, limit)
+                )
+                result.news = articles
+                result.source = DataSource.POLYGON
+                self._stats["polygon_success"] += 1
+
+                if self._cache:
+                    await self._cache.set(
+                        cache_key,
+                        [a.model_dump(mode="json") for a in articles],
+                        ttl=self.NEWS_TTL,
+                    )
+
+                return result
+
+        except (PolygonRateLimitError, PolygonAuthError, PolygonAPIError) as e:
+            self._logger.warning("polygon_news_error", error=str(e))
+            result.errors.append(str(e))
+
+        # Try cache
+        if self._cache:
+            cached = await self._cache.get(cache_key)
+            if cached:
+                result.news = [NewsArticle(**a) for a in cached]
+                result.source = DataSource.CACHE
+                result.cached = True
+                result.fallback_used = True
+                self._stats["cache_fallback"] += 1
+                return result
+
+        # Mock fallback
+        result.news = self._get_mock_news(symbol, limit)
+        result.source = DataSource.MOCK
+        result.fallback_used = True
+        self._stats["mock_fallback"] += 1
+        return result
+
+    # =========================================================================
+    # Yahoo Finance Fallback
+    # =========================================================================
+
+    async def _fetch_yahoo_quote(self, symbol: str) -> Quote | None:
+        """Fetch quote from Yahoo Finance as fallback.
+
+        Args:
+            symbol: Stock ticker symbol.
+
+        Returns:
+            Quote or None if unavailable.
+        """
+        try:
+            import yfinance as yf
+
+            ticker = await asyncio.to_thread(lambda: yf.Ticker(symbol))
+            info = await asyncio.to_thread(lambda: ticker.info)
+
+            if not info or info.get("regularMarketPrice") is None:
+                return None
+
+            price = info.get("regularMarketPrice") or info.get("currentPrice", 0.0)
+            previous_close = info.get("previousClose", price)
+
+            if previous_close and previous_close > 0:
+                change_percent = ((price - previous_close) / previous_close) * 100
+            else:
+                change_percent = 0.0
+
+            return Quote(
+                symbol=symbol,
+                price=float(price),
+                change_percent=round(change_percent, 2),
+                volume=int(info.get("regularMarketVolume", 0)),
+                open=info.get("regularMarketOpen"),
+                high=info.get("regularMarketDayHigh"),
+                low=info.get("regularMarketDayLow"),
+                previous_close=previous_close,
+                source=DataSource.YAHOO,
+            )
+
+        except Exception as e:
+            self._logger.error("yahoo_fetch_error", symbol=symbol, error=str(e))
+            return None
+
+    # =========================================================================
+    # Mock Data Fallback
+    # =========================================================================
+
+    def _get_mock_quote(self, symbol: str) -> Quote:
+        """Generate mock quote data."""
+        mock_prices = {
+            "AAPL": 185.50,
+            "GOOGL": 140.25,
+            "MSFT": 378.90,
+            "AMZN": 178.25,
+            "NVDA": 495.50,
+            "TSLA": 248.50,
+        }
+        price = mock_prices.get(symbol, 100.0)
+
+        return Quote(
+            symbol=symbol,
+            price=price,
+            change_percent=0.0,
+            volume=1_000_000,
+            open=price * 0.99,
+            high=price * 1.01,
+            low=price * 0.98,
+            previous_close=price,
+            source=DataSource.MOCK,
+        )
+
+    def _get_mock_bars(self, symbol: str, limit: int) -> list[Bar]:
+        """Generate mock historical bars."""
+        bars = []
+        base_price = 100.0
+        now = datetime.now()
+
+        for i in range(limit):
+            bars.append(
+                Bar(
+                    symbol=symbol,
+                    open=base_price * (1 + i * 0.001),
+                    high=base_price * (1 + i * 0.002),
+                    low=base_price * (1 - i * 0.001),
+                    close=base_price * (1 + i * 0.0015),
+                    volume=1_000_000 + i * 10000,
+                    timestamp=now.replace(day=max(1, now.day - i)),
+                )
+            )
+
+        return bars
+
+    def _get_mock_company_info(self, symbol: str) -> CompanyInfo:
+        """Generate mock company info."""
+        return CompanyInfo(
+            symbol=symbol,
+            name=f"{symbol} Inc.",
+            description=f"Mock company data for {symbol}",
+            sector="Technology",
+            industry="Software",
+            market_cap=100_000_000_000,
+            exchange="NASDAQ",
+            source=DataSource.MOCK,
+        )
+
+    def _get_mock_news(self, symbol: str | None, limit: int) -> list[NewsArticle]:
+        """Generate mock news articles."""
+        articles = []
+        now = datetime.now()
+
+        for i in range(min(limit, 5)):
+            articles.append(
+                NewsArticle(
+                    id=f"mock-{i}",
+                    title=f"Market Update: {symbol or 'Markets'} Analysis",
+                    author="Mock Author",
+                    publisher="Mock Financial News",
+                    url=f"https://example.com/news/{i}",
+                    summary=f"Mock news summary for {symbol or 'the market'}.",
+                    symbols=[symbol] if symbol else [],
+                    sentiment="neutral",
+                    published_at=now,
+                    source=DataSource.MOCK,
+                )
+            )
+
+        return articles
+
+    async def close(self) -> None:
+        """Close underlying clients."""
+        if self._polygon:
+            await self._polygon.close()

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -16,7 +16,6 @@ from src.tools.base import (
     default_registry,
 )
 from src.tools.market_data import (
-    MarketDataCache,
     MarketDataInput,
     MarketDataOutput,
     MarketDataTool,
@@ -61,7 +60,6 @@ __all__ = [
     "CorrelationTool",
     "ExecutionCosts",
     "ExecutionCostTool",
-    "MarketDataCache",
     "MarketDataInput",
     "MarketDataOutput",
     "MarketDataTool",

--- a/tests/test_cache/test_manager.py
+++ b/tests/test_cache/test_manager.py
@@ -46,9 +46,12 @@ class TestCacheConfig:
         """Test default configuration values."""
         config = CacheConfig()
         assert config.market_data_ttl == 300  # 5 minutes
-        assert config.news_ttl == 3600  # 1 hour
+        assert config.news_ttl == 900  # 15 minutes (optimized for Polygon)
         assert config.analysis_ttl == 86400  # 24 hours
         assert config.recommendation_ttl == 3600  # 1 hour
+        assert config.quote_ttl == 60  # 1 minute (real-time quotes)
+        assert config.daily_bars_ttl == 3600  # 1 hour
+        assert config.company_info_ttl == 86400  # 24 hours
         assert config.default_ttl == 300  # 5 minutes
 
     def test_custom_values(self) -> None:

--- a/tests/test_data/__init__.py
+++ b/tests/test_data/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the data module (Polygon.io integration)."""

--- a/tests/test_data/test_polygon.py
+++ b/tests/test_data/test_polygon.py
@@ -1,0 +1,213 @@
+"""Tests for the Polygon.io client."""
+
+import os
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.data.models import DataSource
+from src.data.polygon import (
+    PolygonAPIError,
+    PolygonAuthError,
+    PolygonClient,
+    PolygonRateLimitError,
+)
+
+
+class TestPolygonClient:
+    """Tests for PolygonClient."""
+
+    def test_init_with_api_key(self) -> None:
+        """Test initialization with explicit API key."""
+        client = PolygonClient(api_key="test_key")
+        assert client.api_key == "test_key"
+        assert client.is_configured is True
+
+    def test_init_from_env(self) -> None:
+        """Test initialization from environment variable."""
+        with patch.dict(os.environ, {"POLYGON_API_KEY": "env_key"}):
+            client = PolygonClient()
+            assert client.api_key == "env_key"
+            assert client.is_configured is True
+
+    def test_init_no_key(self) -> None:
+        """Test initialization without API key."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove POLYGON_API_KEY if it exists
+            os.environ.pop("POLYGON_API_KEY", None)
+            client = PolygonClient(api_key=None)
+            assert client.is_configured is False
+
+    @pytest.mark.asyncio
+    async def test_get_quote_success(self) -> None:
+        """Test successful quote fetch."""
+        client = PolygonClient(api_key="test_key")
+
+        mock_response = {
+            "resultsCount": 1,
+            "results": [
+                {
+                    "c": 185.50,
+                    "o": 184.00,
+                    "h": 186.00,
+                    "l": 183.50,
+                    "v": 50000000,
+                    "t": 1704067200000,  # Unix timestamp in ms
+                }
+            ],
+        }
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = mock_response
+            quote = await client.get_quote("AAPL")
+
+            assert quote.symbol == "AAPL"
+            assert quote.price == 185.50
+            assert quote.volume == 50000000
+            assert quote.source == DataSource.POLYGON
+
+    @pytest.mark.asyncio
+    async def test_get_quote_no_data(self) -> None:
+        """Test quote fetch when no data available."""
+        client = PolygonClient(api_key="test_key")
+
+        mock_response = {"resultsCount": 0, "results": []}
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = mock_response
+
+            with pytest.raises(ValueError, match="No data available"):
+                await client.get_quote("INVALID")
+
+    @pytest.mark.asyncio
+    async def test_get_bars_success(self) -> None:
+        """Test successful bars fetch."""
+        client = PolygonClient(api_key="test_key")
+
+        mock_response = {
+            "results": [
+                {
+                    "o": 184.00,
+                    "h": 186.00,
+                    "l": 183.50,
+                    "c": 185.50,
+                    "v": 50000000,
+                    "vw": 185.00,
+                    "t": 1704067200000,
+                    "n": 100000,
+                },
+                {
+                    "o": 185.50,
+                    "h": 187.00,
+                    "l": 185.00,
+                    "c": 186.50,
+                    "v": 45000000,
+                    "vw": 186.00,
+                    "t": 1704153600000,
+                    "n": 95000,
+                },
+            ]
+        }
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = mock_response
+            bars = await client.get_bars("AAPL", "day", 5)
+
+            assert len(bars) == 2
+            assert bars[0].symbol == "AAPL"
+            assert bars[0].close == 185.50
+            assert bars[0].volume == 50000000
+
+    @pytest.mark.asyncio
+    async def test_get_company_info_success(self) -> None:
+        """Test successful company info fetch."""
+        client = PolygonClient(api_key="test_key")
+
+        mock_response = {
+            "status": "OK",
+            "results": {
+                "name": "Apple Inc.",
+                "description": "Apple designs and manufactures consumer electronics.",
+                "sic_description": "Technology",
+                "market_cap": 2900000000000,
+                "total_employees": 150000,
+                "homepage_url": "https://apple.com",
+                "primary_exchange": "NASDAQ",
+                "currency_name": "USD",
+            },
+        }
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = mock_response
+            info = await client.get_company_info("AAPL")
+
+            assert info.symbol == "AAPL"
+            assert info.name == "Apple Inc."
+            assert info.market_cap == 2900000000000
+            assert info.source == DataSource.POLYGON
+
+    @pytest.mark.asyncio
+    async def test_search_news_success(self) -> None:
+        """Test successful news search."""
+        client = PolygonClient(api_key="test_key")
+
+        mock_response = {
+            "results": [
+                {
+                    "id": "article-1",
+                    "title": "Apple Reports Strong Earnings",
+                    "author": "John Doe",
+                    "publisher": {"name": "Financial Times"},
+                    "article_url": "https://ft.com/article-1",
+                    "description": "Apple beat expectations...",
+                    "tickers": ["AAPL"],
+                    "published_utc": "2024-01-15T10:00:00Z",
+                }
+            ]
+        }
+
+        with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = mock_response
+            articles = await client.search_news("AAPL", limit=5)
+
+            assert len(articles) == 1
+            assert articles[0].title == "Apple Reports Strong Earnings"
+            assert articles[0].publisher == "Financial Times"
+            assert articles[0].source == DataSource.POLYGON
+
+    @pytest.mark.asyncio
+    async def test_request_no_api_key(self) -> None:
+        """Test request without API key raises error."""
+        client = PolygonClient(api_key=None)
+
+        with pytest.raises(PolygonAuthError, match="not configured"):
+            await client._request("/v2/aggs/ticker/AAPL/prev")
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self) -> None:
+        """Test async context manager."""
+        async with PolygonClient(api_key="test_key") as client:
+            assert client.api_key == "test_key"
+
+
+class TestPolygonErrors:
+    """Tests for Polygon error classes."""
+
+    def test_polygon_auth_error(self) -> None:
+        """Test PolygonAuthError."""
+        error = PolygonAuthError("Invalid API key")
+        assert "Invalid API key" in str(error)
+
+    def test_polygon_rate_limit_error(self) -> None:
+        """Test PolygonRateLimitError."""
+        error = PolygonRateLimitError(retry_after=12.0)
+        assert error.retry_after == 12.0
+        assert "Rate limit exceeded" in str(error)
+
+    def test_polygon_api_error(self) -> None:
+        """Test PolygonAPIError."""
+        error = PolygonAPIError(500, "Internal server error")
+        assert error.status == 500
+        assert error.message == "Internal server error"
+        assert "500" in str(error)

--- a/tests/test_data/test_router.py
+++ b/tests/test_data/test_router.py
@@ -1,0 +1,444 @@
+"""Tests for the DataSourceRouter and RateLimitedQueue."""
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.data.models import Bar, CompanyInfo, DataSource, NewsArticle, Quote
+from src.data.polygon import PolygonAPIError, PolygonAuthError, PolygonRateLimitError
+from src.data.router import DataSourceRouter, RateLimitedQueue
+
+
+class TestRateLimitedQueue:
+    """Tests for RateLimitedQueue."""
+
+    def test_init_defaults(self) -> None:
+        """Test initialization with defaults."""
+        queue = RateLimitedQueue()
+        assert queue.refill_interval == 12.0  # 60/5 = 12 seconds
+        assert queue.pending_requests == 0
+
+    def test_init_custom_rate(self) -> None:
+        """Test initialization with custom rate."""
+        queue = RateLimitedQueue(rate_limit=10, window_seconds=60)
+        assert queue.refill_interval == 6.0  # 60/10 = 6 seconds
+
+    @pytest.mark.asyncio
+    async def test_submit_single_request(self) -> None:
+        """Test submitting a single request."""
+        queue = RateLimitedQueue(rate_limit=5)
+
+        async def mock_request() -> str:
+            return "result"
+
+        result = await queue.submit(mock_request())
+        assert result == "result"
+
+    @pytest.mark.asyncio
+    async def test_submit_tracks_pending(self) -> None:
+        """Test that pending count is tracked correctly."""
+        queue = RateLimitedQueue(rate_limit=2)
+
+        async def slow_request() -> str:
+            await asyncio.sleep(0.1)
+            return "done"
+
+        # Both should complete without waiting
+        results = await asyncio.gather(
+            queue.submit(slow_request()),
+            queue.submit(slow_request()),
+        )
+        assert results == ["done", "done"]
+
+    def test_reset(self) -> None:
+        """Test queue reset."""
+        queue = RateLimitedQueue(rate_limit=5)
+        queue._pending_count = 3
+        queue.reset()
+        assert queue.pending_requests == 0
+
+
+class TestDataSourceRouter:
+    """Tests for DataSourceRouter."""
+
+    def test_init_defaults(self) -> None:
+        """Test initialization with defaults."""
+        router = DataSourceRouter()
+        assert router.stats["polygon_success"] == 0
+        assert router.stats["mock_fallback"] == 0
+
+    def test_init_with_polygon(self) -> None:
+        """Test initialization with Polygon client."""
+        mock_polygon = MagicMock()
+        router = DataSourceRouter(polygon=mock_polygon)
+        assert router._polygon == mock_polygon
+
+    def test_stats_reset(self) -> None:
+        """Test stats reset."""
+        router = DataSourceRouter()
+        router._stats["polygon_success"] = 5
+        router.reset_stats()
+        assert router.stats["polygon_success"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_quote_polygon_success(self) -> None:
+        """Test successful quote fetch from Polygon."""
+        mock_polygon = MagicMock()
+        mock_polygon.is_configured = True
+
+        mock_quote = Quote(
+            symbol="AAPL",
+            price=185.50,
+            change_percent=1.2,
+            volume=50_000_000,
+            source=DataSource.POLYGON,
+        )
+
+        async def mock_get_quote(symbol: str) -> Quote:
+            return mock_quote
+
+        mock_polygon.get_quote = mock_get_quote
+
+        router = DataSourceRouter(polygon=mock_polygon)
+        result = await router.get_quote("AAPL")
+
+        assert result.quote is not None
+        assert result.quote.symbol == "AAPL"
+        assert result.quote.price == 185.50
+        assert result.source == DataSource.POLYGON
+        assert not result.fallback_used
+        assert router.stats["polygon_success"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_quote_yahoo_fallback(self) -> None:
+        """Test quote fetch falls back to Yahoo when Polygon not configured."""
+        mock_polygon = MagicMock()
+        mock_polygon.is_configured = False
+
+        mock_yahoo_quote = Quote(
+            symbol="AAPL",
+            price=186.00,
+            change_percent=0.5,
+            volume=45_000_000,
+            source=DataSource.YAHOO,
+        )
+
+        router = DataSourceRouter(polygon=mock_polygon)
+
+        # Mock Yahoo to return a quote
+        async def mock_yahoo(symbol: str) -> Quote:
+            return mock_yahoo_quote
+
+        with patch.object(router, "_fetch_yahoo_quote", side_effect=mock_yahoo):
+            result = await router.get_quote("AAPL")
+
+            assert result.quote is not None
+            assert result.source == DataSource.YAHOO
+            assert result.quote.price == 186.00
+            assert result.fallback_used
+            assert router.stats["yahoo_fallback"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_quote_polygon_not_configured(self) -> None:
+        """Test quote fetch when Polygon is not configured and Yahoo fails."""
+        mock_polygon = MagicMock()
+        mock_polygon.is_configured = False
+
+        router = DataSourceRouter(polygon=mock_polygon)
+
+        # Mock Yahoo to fail so we hit mock fallback
+        with patch.object(router, "_fetch_yahoo_quote", return_value=None):
+            result = await router.get_quote("AAPL")
+
+            # Should fallback to mock
+            assert result.quote is not None
+            assert result.source == DataSource.MOCK
+            assert result.fallback_used
+            assert router.stats["mock_fallback"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_quote_polygon_rate_limited(self) -> None:
+        """Test quote fetch when Polygon is rate limited and Yahoo fails."""
+        mock_polygon = MagicMock()
+        mock_polygon.is_configured = True
+
+        async def mock_get_quote_rate_limited(symbol: str) -> Quote:
+            raise PolygonRateLimitError(retry_after=60.0)
+
+        mock_polygon.get_quote = mock_get_quote_rate_limited
+
+        router = DataSourceRouter(polygon=mock_polygon)
+
+        # Mock Yahoo to fail so we hit mock fallback
+        with patch.object(router, "_fetch_yahoo_quote", return_value=None):
+            result = await router.get_quote("AAPL")
+
+            # Should fallback to mock (Yahoo and cache not available)
+            assert result.quote is not None
+            assert result.source == DataSource.MOCK
+            assert result.fallback_used
+            assert router.stats["polygon_rate_limited"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_quote_with_cache_fallback(self) -> None:
+        """Test quote fetch falls back to cache when Polygon and Yahoo fail."""
+        mock_polygon = MagicMock()
+        mock_polygon.is_configured = True
+
+        async def mock_get_quote_error(symbol: str) -> Quote:
+            raise PolygonAPIError(500, "Server error")
+
+        mock_polygon.get_quote = mock_get_quote_error
+
+        # Mock cache with stored quote
+        mock_cache = AsyncMock()
+        cached_quote = {
+            "symbol": "AAPL",
+            "price": 180.00,
+            "change_percent": 0.5,
+            "volume": 40_000_000,
+            "source": "cache",
+            "timestamp": datetime.now().isoformat(),
+        }
+        mock_cache.get = AsyncMock(return_value=cached_quote)
+
+        router = DataSourceRouter(polygon=mock_polygon, cache=mock_cache)
+
+        # Mock Yahoo to fail so we hit cache fallback
+        with patch.object(router, "_fetch_yahoo_quote", return_value=None):
+            result = await router.get_quote("AAPL")
+
+            assert result.quote is not None
+            assert result.source == DataSource.CACHE
+            assert result.cached
+            assert result.fallback_used
+            assert router.stats["cache_fallback"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_quote_caches_result(self) -> None:
+        """Test that successful quote is cached."""
+        mock_polygon = MagicMock()
+        mock_polygon.is_configured = True
+
+        mock_quote = Quote(
+            symbol="AAPL",
+            price=185.50,
+            change_percent=1.2,
+            volume=50_000_000,
+            source=DataSource.POLYGON,
+        )
+
+        async def mock_get_quote(symbol: str) -> Quote:
+            return mock_quote
+
+        mock_polygon.get_quote = mock_get_quote
+
+        mock_cache = AsyncMock()
+        mock_cache.set = AsyncMock()
+
+        router = DataSourceRouter(polygon=mock_polygon, cache=mock_cache)
+        await router.get_quote("AAPL")
+
+        # Verify cache was called
+        mock_cache.set.assert_called_once()
+        call_args = mock_cache.set.call_args
+        # CacheKeyBuilder uses "portfolio_advisor:market:AAPL:quote" format
+        assert "AAPL" in call_args[0][0]
+        assert "quote" in call_args[0][0]
+        assert call_args[1]["ttl"] == DataSourceRouter.QUOTE_TTL
+
+    @pytest.mark.asyncio
+    async def test_get_bars_polygon_success(self) -> None:
+        """Test successful bars fetch from Polygon."""
+        mock_polygon = MagicMock()
+        mock_polygon.is_configured = True
+
+        mock_bars = [
+            Bar(
+                symbol="AAPL",
+                open=184.0,
+                high=186.0,
+                low=183.5,
+                close=185.5,
+                volume=50_000_000,
+                timestamp=datetime.now(),
+            ),
+            Bar(
+                symbol="AAPL",
+                open=185.5,
+                high=187.0,
+                low=185.0,
+                close=186.5,
+                volume=45_000_000,
+                timestamp=datetime.now(),
+            ),
+        ]
+
+        async def mock_get_bars(symbol: str, timeframe: str, limit: int) -> list[Bar]:
+            return mock_bars
+
+        mock_polygon.get_bars = mock_get_bars
+
+        router = DataSourceRouter(polygon=mock_polygon)
+        result = await router.get_bars("AAPL", "day", 5)
+
+        assert result.bars is not None
+        assert len(result.bars) == 2
+        assert result.source == DataSource.POLYGON
+        assert router.stats["polygon_success"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_bars_mock_fallback(self) -> None:
+        """Test bars fetch falls back to mock."""
+        mock_polygon = MagicMock()
+        mock_polygon.is_configured = False
+
+        router = DataSourceRouter(polygon=mock_polygon)
+        result = await router.get_bars("AAPL", "day", 5)
+
+        assert result.bars is not None
+        assert len(result.bars) == 5
+        assert result.source == DataSource.MOCK
+        assert result.fallback_used
+        assert router.stats["mock_fallback"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_company_info_polygon_success(self) -> None:
+        """Test successful company info fetch from Polygon."""
+        mock_polygon = MagicMock()
+        mock_polygon.is_configured = True
+
+        mock_info = CompanyInfo(
+            symbol="AAPL",
+            name="Apple Inc.",
+            description="Technology company",
+            sector="Technology",
+            market_cap=2_900_000_000_000,
+            source=DataSource.POLYGON,
+        )
+
+        async def mock_get_company_info(symbol: str) -> CompanyInfo:
+            return mock_info
+
+        mock_polygon.get_company_info = mock_get_company_info
+
+        router = DataSourceRouter(polygon=mock_polygon)
+        result = await router.get_company_info("AAPL")
+
+        assert result.company_info is not None
+        assert result.company_info.name == "Apple Inc."
+        assert result.source == DataSource.POLYGON
+        assert router.stats["polygon_success"] == 1
+
+    @pytest.mark.asyncio
+    async def test_search_news_polygon_success(self) -> None:
+        """Test successful news search from Polygon."""
+        mock_polygon = MagicMock()
+        mock_polygon.is_configured = True
+
+        mock_articles = [
+            NewsArticle(
+                id="article-1",
+                title="Apple Reports Strong Earnings",
+                author="John Doe",
+                publisher="Financial Times",
+                url="https://ft.com/article-1",
+                summary="Apple beat expectations...",
+                symbols=["AAPL"],
+                published_at=datetime.now(),
+                source=DataSource.POLYGON,
+            )
+        ]
+
+        async def mock_search_news(symbol: str | None, limit: int) -> list[NewsArticle]:
+            return mock_articles
+
+        mock_polygon.search_news = mock_search_news
+
+        router = DataSourceRouter(polygon=mock_polygon)
+        result = await router.search_news("AAPL", limit=5)
+
+        assert result.news is not None
+        assert len(result.news) == 1
+        assert result.news[0].title == "Apple Reports Strong Earnings"
+        assert result.source == DataSource.POLYGON
+        assert router.stats["polygon_success"] == 1
+
+    @pytest.mark.asyncio
+    async def test_search_news_mock_fallback(self) -> None:
+        """Test news search falls back to mock."""
+        mock_polygon = MagicMock()
+        mock_polygon.is_configured = False
+
+        router = DataSourceRouter(polygon=mock_polygon)
+        result = await router.search_news("AAPL", limit=3)
+
+        assert result.news is not None
+        assert len(result.news) == 3
+        assert result.source == DataSource.MOCK
+        assert result.fallback_used
+
+    @pytest.mark.asyncio
+    async def test_close(self) -> None:
+        """Test closing the router."""
+        mock_polygon = AsyncMock()
+        router = DataSourceRouter(polygon=mock_polygon)
+        await router.close()
+        mock_polygon.close.assert_called_once()
+
+
+class TestMockData:
+    """Tests for mock data generation."""
+
+    @pytest.mark.asyncio
+    async def test_mock_quote_known_symbol(self) -> None:
+        """Test mock quote for known symbol when all sources fail."""
+        router = DataSourceRouter(polygon=MagicMock(is_configured=False))
+
+        # Mock Yahoo to fail so we hit mock fallback
+        with patch.object(router, "_fetch_yahoo_quote", return_value=None):
+            result = await router.get_quote("AAPL")
+
+            assert result.quote is not None
+            assert result.quote.price == 185.50
+            assert result.source == DataSource.MOCK
+
+    @pytest.mark.asyncio
+    async def test_mock_quote_unknown_symbol(self) -> None:
+        """Test mock quote for unknown symbol when all sources fail."""
+        router = DataSourceRouter(polygon=MagicMock(is_configured=False))
+
+        # Mock Yahoo to fail so we hit mock fallback
+        with patch.object(router, "_fetch_yahoo_quote", return_value=None):
+            result = await router.get_quote("UNKNOWN")
+
+            assert result.quote is not None
+            assert result.quote.price == 100.0  # Default price
+            assert result.source == DataSource.MOCK
+
+    @pytest.mark.asyncio
+    async def test_mock_bars_generates_correct_count(self) -> None:
+        """Test mock bars generates requested count when Polygon not configured."""
+        router = DataSourceRouter(polygon=MagicMock(is_configured=False))
+        # Bars only use Polygon and cache, no Yahoo fallback
+        result = await router.get_bars("AAPL", "day", 10)
+
+        assert result.bars is not None
+        assert len(result.bars) == 10
+
+    @pytest.mark.asyncio
+    async def test_mock_news_limits_correctly(self) -> None:
+        """Test mock news respects limit when Polygon not configured."""
+        router = DataSourceRouter(polygon=MagicMock(is_configured=False))
+        # News only uses Polygon and cache, no Yahoo fallback
+
+        # Request more than max mock articles
+        result = await router.search_news("AAPL", limit=10)
+        assert result.news is not None
+        assert len(result.news) == 5  # Max mock articles
+
+        # Request fewer
+        result = await router.search_news("AAPL", limit=2)
+        assert len(result.news) == 2

--- a/tests/test_tools/test_market_data.py
+++ b/tests/test_tools/test_market_data.py
@@ -1,15 +1,15 @@
 """Tests for the Market Data Tool."""
 
-from typing import Any
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.data.models import DataSource, MarketDataResult, Quote
 from src.tools.base import ToolExecutionError
 from src.tools.market_data import (
     DEFAULT_MOCK,
     MOCK_STOCKS,
-    MarketDataCache,
     MarketDataInput,
     MarketDataOutput,
     MarketDataTool,
@@ -50,11 +50,11 @@ class TestMarketDataOutput:
             change_percent=1.2,
             volume=50_000_000,
             timestamp="2024-01-15T10:00:00",
-            source="real",
+            source="polygon",
         )
         assert output.symbol == "AAPL"
         assert output.price == 185.50
-        assert output.source == "real"
+        assert output.source == "polygon"
         assert output.success is True
 
     def test_optional_fields(self) -> None:
@@ -90,120 +90,18 @@ class TestMarketDataOutput:
         assert output.fifty_two_week_high == 199.62
 
 
-class TestMarketDataCache:
-    """Tests for MarketDataCache."""
-
-    @pytest.fixture
-    def mock_redis(self) -> MagicMock:
-        """Create mock Redis client."""
-        return MagicMock()
-
-    @pytest.mark.asyncio
-    async def test_cache_key_format(self) -> None:
-        """Test cache key generation."""
-        cache = MarketDataCache()
-        key = cache._cache_key("aapl", "quote")
-        assert key == "market_data:AAPL:quote"
-
-    @pytest.mark.asyncio
-    async def test_cache_get_miss(self) -> None:
-        """Test cache miss returns None."""
-        cache = MarketDataCache()
-        mock_client = AsyncMock()
-        mock_client.get.return_value = None
-        cache._client = mock_client
-
-        result = await cache.get("AAPL", "quote")
-
-        assert result is None
-        mock_client.get.assert_called_once_with("market_data:AAPL:quote")
-
-    @pytest.mark.asyncio
-    async def test_cache_get_hit(self) -> None:
-        """Test cache hit returns data."""
-        cache = MarketDataCache()
-        mock_client = AsyncMock()
-        cached_data = MarketDataOutput(
-            symbol="AAPL",
-            price=185.50,
-            change_percent=1.2,
-            volume=50_000_000,
-            timestamp="2024-01-15T10:00:00",
-            source="cache",
-        )
-        mock_client.get.return_value = cached_data.model_dump_json()
-        cache._client = mock_client
-
-        result = await cache.get("AAPL", "quote")
-
-        assert result is not None
-        assert result.symbol == "AAPL"
-        assert result.price == 185.50
-
-    @pytest.mark.asyncio
-    async def test_cache_set(self) -> None:
-        """Test setting cache."""
-        cache = MarketDataCache(ttl=300)
-        mock_client = AsyncMock()
-        mock_client.setex.return_value = True
-        cache._client = mock_client
-
-        data = MarketDataOutput(
-            symbol="AAPL",
-            price=185.50,
-            change_percent=1.2,
-            volume=50_000_000,
-            timestamp="2024-01-15T10:00:00",
-            source="real",
-        )
-
-        result = await cache.set("AAPL", "quote", data)
-
-        assert result is True
-        mock_client.setex.assert_called_once()
-        call_args = mock_client.setex.call_args
-        assert call_args[0][0] == "market_data:AAPL:quote"
-        assert call_args[0][1] == 300
-
-    @pytest.mark.asyncio
-    async def test_cache_error_handling(self) -> None:
-        """Test cache handles Redis errors gracefully."""
-        import redis.asyncio as redis_async
-
-        cache = MarketDataCache()
-        mock_client = AsyncMock()
-        mock_client.get.side_effect = redis_async.RedisError("Connection failed")
-        cache._client = mock_client
-
-        result = await cache.get("AAPL", "quote")
-
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_cache_close(self) -> None:
-        """Test closing cache connection."""
-        cache = MarketDataCache()
-        mock_client = AsyncMock()
-        cache._client = mock_client
-
-        await cache.close()
-
-        mock_client.close.assert_called_once()
-        assert cache._client is None
-
-
 class TestMarketDataTool:
     """Tests for MarketDataTool."""
 
     def test_tool_properties(self) -> None:
         """Test tool has correct name and description."""
-        tool = MarketDataTool()
+        tool = MarketDataTool(use_mock=True)
         assert tool.name == "get_market_data"
         assert "market data" in tool.description.lower()
 
     def test_to_anthropic_tool(self) -> None:
         """Test conversion to Anthropic tool format."""
-        tool = MarketDataTool()
+        tool = MarketDataTool(use_mock=True)
         anthropic_tool = tool.to_anthropic_tool()
 
         assert anthropic_tool["name"] == "get_market_data"
@@ -251,168 +149,166 @@ class TestMarketDataTool:
         assert result.fifty_two_week_high == MOCK_STOCKS["AAPL"]["fifty_two_week_high"]
         assert result.timestamp is not None
 
+
+class TestMarketDataToolWithRouter:
+    """Tests for MarketDataTool with DataSourceRouter."""
+
     @pytest.mark.asyncio
-    async def test_execute_real_with_cache_hit(self) -> None:
-        """Test real execution uses cache when available."""
-        mock_cache = AsyncMock(spec=MarketDataCache)
-        cached_data = MarketDataOutput(
+    async def test_execute_real_uses_router(self) -> None:
+        """Test real execution uses DataSourceRouter."""
+        mock_router = MagicMock()
+        mock_quote = Quote(
             symbol="AAPL",
             price=185.50,
             change_percent=1.2,
             volume=50_000_000,
-            timestamp="2024-01-15T10:00:00",
-            source="cache",
+            high=186.00,
+            low=184.00,
+            timestamp=datetime.now(),
+            source=DataSource.POLYGON,
         )
-        mock_cache.get.return_value = cached_data
+        mock_result = MarketDataResult(
+            symbol="AAPL",
+            quote=mock_quote,
+            source=DataSource.POLYGON,
+        )
 
-        tool = MarketDataTool(use_mock=False, cache=mock_cache)
+        async def mock_get_quote(symbol: str) -> MarketDataResult:
+            return mock_result
+
+        mock_router.get_quote = mock_get_quote
+
+        tool = MarketDataTool(use_mock=False, router=mock_router)
         result = await tool.execute({"symbol": "AAPL"})
 
-        assert result.source == "cache"
+        assert result.symbol == "AAPL"
         assert result.price == 185.50
-        mock_cache.get.assert_called_once_with("AAPL", "quote")
+        assert result.source == "polygon"
 
     @pytest.mark.asyncio
-    async def test_execute_real_fetches_data(self) -> None:
-        """Test real execution fetches from yfinance."""
-        mock_cache = AsyncMock(spec=MarketDataCache)
-        mock_cache.get.return_value = None  # Cache miss
+    async def test_execute_real_yahoo_fallback(self) -> None:
+        """Test real execution with Yahoo fallback."""
+        mock_router = MagicMock()
+        mock_quote = Quote(
+            symbol="AAPL",
+            price=186.00,
+            change_percent=0.8,
+            volume=48_000_000,
+            timestamp=datetime.now(),
+            source=DataSource.YAHOO,
+        )
+        mock_result = MarketDataResult(
+            symbol="AAPL",
+            quote=mock_quote,
+            source=DataSource.YAHOO,
+            fallback_used=True,
+        )
 
-        tool = MarketDataTool(use_mock=False, cache=mock_cache)
+        async def mock_get_quote(symbol: str) -> MarketDataResult:
+            return mock_result
 
-        mock_ticker_data: dict[str, Any] = {
-            "price": 190.50,
-            "change_percent": 1.5,
-            "volume": 55_000_000,
-            "market_cap": 3.0e12,
-            "pe_ratio": 29.0,
-            "dividend_yield": 0.6,
-            "fifty_two_week_high": 200.0,
-            "fifty_two_week_low": 165.0,
-        }
+        mock_router.get_quote = mock_get_quote
 
-        with patch.object(tool, "_fetch_yfinance_data", return_value=mock_ticker_data):
-            result = await tool.execute({"symbol": "AAPL"})
+        tool = MarketDataTool(use_mock=False, router=mock_router)
+        result = await tool.execute({"symbol": "AAPL"})
 
         assert result.symbol == "AAPL"
-        assert result.price == 190.50
-        assert result.source == "real"
-        mock_cache.set.assert_called_once()
+        assert result.source == "yahoo"
 
     @pytest.mark.asyncio
-    async def test_execute_real_invalid_symbol(self) -> None:
-        """Test real execution handles invalid symbols."""
-        mock_cache = AsyncMock(spec=MarketDataCache)
-        mock_cache.get.return_value = None
+    async def test_execute_real_cache_fallback(self) -> None:
+        """Test real execution with cache fallback."""
+        mock_router = MagicMock()
+        mock_quote = Quote(
+            symbol="AAPL",
+            price=184.00,
+            change_percent=0.5,
+            volume=45_000_000,
+            timestamp=datetime.now(),
+            source=DataSource.CACHE,
+        )
+        mock_result = MarketDataResult(
+            symbol="AAPL",
+            quote=mock_quote,
+            source=DataSource.CACHE,
+            cached=True,
+            fallback_used=True,
+        )
 
-        tool = MarketDataTool(use_mock=False, fallback_to_mock=False, cache=mock_cache)
+        async def mock_get_quote(symbol: str) -> MarketDataResult:
+            return mock_result
 
-        with (
-            patch.object(tool, "_fetch_yfinance_data", return_value=None),
-            pytest.raises(ToolExecutionError),
-        ):
-            await tool.execute({"symbol": "INVALID"})
+        mock_router.get_quote = mock_get_quote
+
+        tool = MarketDataTool(use_mock=False, router=mock_router)
+        result = await tool.execute({"symbol": "AAPL"})
+
+        assert result.symbol == "AAPL"
+        assert result.source == "cache"
 
     @pytest.mark.asyncio
-    async def test_execute_real_fallback_to_mock(self) -> None:
-        """Test fallback to mock when real API fails."""
-        mock_cache = AsyncMock(spec=MarketDataCache)
-        mock_cache.get.return_value = None
+    async def test_execute_real_mock_fallback(self) -> None:
+        """Test real execution with mock fallback."""
+        mock_router = MagicMock()
+        mock_quote = Quote(
+            symbol="AAPL",
+            price=185.50,
+            change_percent=0.0,
+            volume=1_000_000,
+            timestamp=datetime.now(),
+            source=DataSource.MOCK,
+        )
+        mock_result = MarketDataResult(
+            symbol="AAPL",
+            quote=mock_quote,
+            source=DataSource.MOCK,
+            fallback_used=True,
+        )
 
-        tool = MarketDataTool(use_mock=False, fallback_to_mock=True, cache=mock_cache)
+        async def mock_get_quote(symbol: str) -> MarketDataResult:
+            return mock_result
 
-        with patch.object(tool, "_fetch_yfinance_data", return_value=None):
-            result = await tool.execute({"symbol": "AAPL"})
+        mock_router.get_quote = mock_get_quote
 
+        tool = MarketDataTool(use_mock=False, router=mock_router)
+        result = await tool.execute({"symbol": "AAPL"})
+
+        assert result.symbol == "AAPL"
+        assert result.source == "mock"
+
+    @pytest.mark.asyncio
+    async def test_execute_real_no_quote_falls_back_to_mock(self) -> None:
+        """Test real execution falls back to mock when no quote available."""
+        mock_router = MagicMock()
+        mock_result = MarketDataResult(
+            symbol="INVALID",
+            quote=None,
+            source=DataSource.MOCK,
+            fallback_used=True,
+        )
+
+        async def mock_get_quote(symbol: str) -> MarketDataResult:
+            return mock_result
+
+        mock_router.get_quote = mock_get_quote
+
+        tool = MarketDataTool(use_mock=False, router=mock_router)
+
+        # Tool falls back to mock mode when real data fails
+        result = await tool.execute({"symbol": "INVALID"})
+        assert result.symbol == "INVALID"
         assert result.source == "mock"
         assert result.success is True
-        assert "Fallback" in (result.error or "")
 
     @pytest.mark.asyncio
-    async def test_execute_without_cache(self) -> None:
-        """Test execution without cache."""
-        tool = MarketDataTool(use_mock=False, use_cache=False)
+    async def test_close_closes_router(self) -> None:
+        """Test closing tool closes router."""
+        mock_router = AsyncMock()
+        tool = MarketDataTool(use_mock=False, router=mock_router)
 
-        mock_ticker_data: dict[str, Any] = {
-            "price": 190.50,
-            "change_percent": 1.5,
-            "volume": 55_000_000,
-        }
+        await tool.close()
 
-        with patch.object(tool, "_fetch_yfinance_data", return_value=mock_ticker_data):
-            result = await tool.execute({"symbol": "AAPL"})
-
-        assert result.price == 190.50
-        assert result.source == "real"
-
-
-class TestYFinanceIntegration:
-    """Tests for yfinance data fetching."""
-
-    def test_fetch_yfinance_data_success(self) -> None:
-        """Test successful yfinance data fetch."""
-        tool = MarketDataTool()
-
-        mock_ticker = MagicMock()
-        mock_ticker.info = {
-            "regularMarketPrice": 185.50,
-            "previousClose": 183.00,
-            "regularMarketVolume": 50_000_000,
-            "marketCap": 2_900_000_000_000,
-            "trailingPE": 28.5,
-            "dividendYield": 0.005,
-            "fiftyTwoWeekHigh": 199.62,
-            "fiftyTwoWeekLow": 164.08,
-        }
-
-        with patch("yfinance.Ticker", return_value=mock_ticker):
-            result = tool._fetch_yfinance_data("AAPL")
-
-        assert result is not None
-        assert result["price"] == 185.50
-        assert abs(result["change_percent"] - 1.37) < 0.01  # (185.5-183)/183 * 100
-        assert result["volume"] == 50_000_000
-        assert result["dividend_yield"] == 0.5  # Converted from 0.005 to 0.5%
-
-    def test_fetch_yfinance_data_no_price(self) -> None:
-        """Test handling of ticker with no price data."""
-        tool = MarketDataTool()
-
-        mock_ticker = MagicMock()
-        mock_ticker.info = {"symbol": "INVALID", "regularMarketPrice": None}
-
-        with patch("yfinance.Ticker", return_value=mock_ticker):
-            result = tool._fetch_yfinance_data("INVALID")
-
-        assert result is None
-
-    def test_fetch_yfinance_data_empty_info(self) -> None:
-        """Test handling of empty ticker info."""
-        tool = MarketDataTool()
-
-        mock_ticker = MagicMock()
-        mock_ticker.info = {}
-
-        with patch("yfinance.Ticker", return_value=mock_ticker):
-            result = tool._fetch_yfinance_data("INVALID")
-
-        assert result is None
-
-    def test_fetch_yfinance_data_exception(self) -> None:
-        """Test handling of yfinance exception."""
-        tool = MarketDataTool()
-
-        with patch("yfinance.Ticker", side_effect=Exception("API Error")):
-            result = tool._fetch_yfinance_data("AAPL")
-
-        assert result is None
-
-    def test_to_percent_conversion(self) -> None:
-        """Test percentage conversion utility."""
-        assert MarketDataTool._to_percent(0.005) == 0.5
-        assert MarketDataTool._to_percent(0.0125) == 1.25
-        assert MarketDataTool._to_percent(None) is None
-        assert MarketDataTool._to_percent(0) == 0.0
+        mock_router.close.assert_called_once()
 
 
 class TestMarketDataToolInputValidation:


### PR DESCRIPTION
## Summary

Implements real market data integration with Polygon.io API as per issue #76:

- **PolygonClient**: Async HTTP client for Polygon.io REST API with support for quotes, historical bars, company info, and news
- **RateLimitedQueue**: Token bucket rate limiter respecting 5 req/min free tier limit
- **DataSourceRouter**: Intelligent fallback chain (Polygon → Yahoo → Cache → Mock) with statistics tracking
- **Tiered TTLs**: Optimized cache TTLs (1min quotes, 1h bars, 24h company info, 15min news)
- **MarketDataTool refactor**: Now uses DataSourceRouter for real market data
- **ResearchAgent update**: Integrated with real market data tools

## Test plan

- [x] Unit tests for PolygonClient API methods (37 tests)
- [x] Unit tests for RateLimitedQueue rate limiting
- [x] Unit tests for DataSourceRouter fallback chain
- [x] Unit tests for MarketDataTool with router integration
- [x] Updated cache manager tests for new TTLs
- [x] Full test suite passes (1229 tests)

## Configuration

Set `POLYGON_API_KEY` environment variable to enable real market data. Without it, the system gracefully falls back to Yahoo Finance, cache, or mock data.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)