### PR TITLE
feat: Add prompt caching for cost optimization (#79)

### DIFF
--- a/src/caching/__init__.py
+++ b/src/caching/__init__.py
@@ -1,0 +1,44 @@
+"""Prompt caching module for Claude API optimization.
+
+This module provides utilities for implementing Claude's prompt caching
+to reduce costs and latency for repeated system prompts and context.
+
+Key features:
+- CachedPromptBuilder: Build prompts with optimal cache breakpoints
+- CacheMetrics: Track cache hits/misses and cost savings
+- CacheObservabilityReporter: Report metrics to Langfuse
+"""
+
+from src.caching.metrics import CacheMetrics, CacheMetricsCollector
+from src.caching.observability import (
+    CacheObservabilityConfig,
+    CacheObservabilityReporter,
+    create_cache_reporter,
+)
+from src.caching.prompt_cache import (
+    CacheableContent,
+    CacheControl,
+    CachedPromptBuilder,
+    build_cached_system_prompt,
+    build_cached_tool_definitions,
+    estimate_cache_tokens,
+    is_cacheable,
+)
+
+__all__ = [
+    # Prompt building
+    "CacheControl",
+    "CacheableContent",
+    "CachedPromptBuilder",
+    "build_cached_system_prompt",
+    "build_cached_tool_definitions",
+    "estimate_cache_tokens",
+    "is_cacheable",
+    # Metrics
+    "CacheMetrics",
+    "CacheMetricsCollector",
+    # Observability
+    "CacheObservabilityConfig",
+    "CacheObservabilityReporter",
+    "create_cache_reporter",
+]

--- a/src/caching/metrics.py
+++ b/src/caching/metrics.py
@@ -1,0 +1,375 @@
+"""Cache metrics tracking for observability.
+
+This module provides tracking and analysis of prompt cache performance,
+including hit rates, cost savings, and integration with Langfuse.
+"""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from langfuse import get_client
+
+logger = structlog.get_logger(__name__)
+
+
+# Cost multipliers for cache operations (relative to base input token cost)
+CACHE_WRITE_COST_MULTIPLIER = 1.25  # 25% more than base input tokens
+CACHE_READ_COST_MULTIPLIER = 0.10  # 10% of base input token price
+
+
+@dataclass
+class CacheMetrics:
+    """Metrics for a single API call with caching.
+
+    Attributes:
+        input_tokens: Regular input tokens processed.
+        output_tokens: Output tokens generated.
+        cache_creation_tokens: Tokens written to cache (first call).
+        cache_read_tokens: Tokens read from cache (subsequent calls).
+        model: Model used for the call.
+        agent_name: Name of the agent making the call.
+        timestamp: When the call was made.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cache_read_tokens: int = 0
+    model: str = ""
+    agent_name: str = ""
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    @property
+    def total_input_tokens(self) -> int:
+        """Total input tokens including cached.
+
+        Returns:
+            Sum of regular and cached input tokens.
+        """
+        return self.input_tokens + self.cache_read_tokens
+
+    @property
+    def cache_hit_rate(self) -> float:
+        """Calculate the cache hit rate.
+
+        Returns:
+            Percentage of input tokens read from cache (0-1).
+        """
+        total = self.total_input_tokens
+        if total == 0:
+            return 0.0
+        return self.cache_read_tokens / total
+
+    @property
+    def estimated_savings_percent(self) -> float:
+        """Estimate cost savings from caching.
+
+        Calculates the percentage cost reduction compared to
+        processing all tokens without caching.
+
+        Returns:
+            Estimated savings as a percentage (0-100).
+        """
+        if self.cache_read_tokens == 0:
+            return 0.0
+
+        # Cost without caching: all tokens at full price
+        uncached_cost = self.total_input_tokens
+
+        # Cost with caching: read tokens at 10% + creation tokens at 125%
+        cached_cost = (
+            self.input_tokens
+            + (self.cache_read_tokens * CACHE_READ_COST_MULTIPLIER)
+            + (self.cache_creation_tokens * CACHE_WRITE_COST_MULTIPLIER)
+        )
+
+        if uncached_cost == 0:
+            return 0.0
+
+        savings = (uncached_cost - cached_cost) / uncached_cost * 100
+        return max(0.0, savings)  # Ensure non-negative
+
+    @property
+    def is_cache_hit(self) -> bool:
+        """Check if this call had a cache hit.
+
+        Returns:
+            True if any tokens were read from cache.
+        """
+        return self.cache_read_tokens > 0
+
+    @property
+    def is_cache_creation(self) -> bool:
+        """Check if this call created a cache entry.
+
+        Returns:
+            True if tokens were written to cache.
+        """
+        return self.cache_creation_tokens > 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for logging/storage.
+
+        Returns:
+            Dictionary representation of metrics.
+        """
+        return {
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_creation_tokens": self.cache_creation_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "total_input_tokens": self.total_input_tokens,
+            "cache_hit_rate": round(self.cache_hit_rate, 4),
+            "estimated_savings_percent": round(self.estimated_savings_percent, 2),
+            "is_cache_hit": self.is_cache_hit,
+            "is_cache_creation": self.is_cache_creation,
+            "model": self.model,
+            "agent_name": self.agent_name,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+    @classmethod
+    def from_response(
+        cls,
+        response: Any,
+        *,
+        model: str = "",
+        agent_name: str = "",
+    ) -> "CacheMetrics":
+        """Create metrics from an Anthropic API response.
+
+        Args:
+            response: Anthropic API response object.
+            model: Model name for tracking.
+            agent_name: Agent name for tracking.
+
+        Returns:
+            CacheMetrics populated from response usage data.
+        """
+        usage = getattr(response, "usage", None)
+        if usage is None:
+            return cls(model=model, agent_name=agent_name)
+
+        return cls(
+            input_tokens=getattr(usage, "input_tokens", 0),
+            output_tokens=getattr(usage, "output_tokens", 0),
+            cache_creation_tokens=getattr(usage, "cache_creation_input_tokens", 0),
+            cache_read_tokens=getattr(usage, "cache_read_input_tokens", 0),
+            model=model,
+            agent_name=agent_name,
+        )
+
+    @classmethod
+    def from_usage_dict(
+        cls,
+        usage: dict[str, int],
+        *,
+        model: str = "",
+        agent_name: str = "",
+    ) -> "CacheMetrics":
+        """Create metrics from a usage dictionary.
+
+        Args:
+            usage: Dictionary with token counts.
+            model: Model name for tracking.
+            agent_name: Agent name for tracking.
+
+        Returns:
+            CacheMetrics populated from usage dict.
+        """
+        return cls(
+            input_tokens=usage.get("input_tokens", 0),
+            output_tokens=usage.get("output_tokens", 0),
+            cache_creation_tokens=usage.get("cache_creation_input_tokens", 0),
+            cache_read_tokens=usage.get("cache_read_input_tokens", 0),
+            model=model,
+            agent_name=agent_name,
+        )
+
+
+class CacheMetricsCollector:
+    """Collector for aggregating cache metrics across multiple calls.
+
+    Tracks cache performance over time and can report to Langfuse
+    for observability dashboards.
+
+    Example:
+        collector = CacheMetricsCollector(workflow_id="wf-123")
+
+        # After each API call
+        metrics = CacheMetrics.from_response(response, agent_name="research")
+        collector.record(metrics)
+
+        # At end of workflow
+        summary = collector.get_summary()
+        collector.report_to_langfuse()
+    """
+
+    def __init__(
+        self,
+        workflow_id: str | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        """Initialize the collector.
+
+        Args:
+            workflow_id: Optional workflow ID for grouping.
+            session_id: Optional session ID for Langfuse.
+        """
+        self.workflow_id = workflow_id
+        self.session_id = session_id
+        self._metrics: list[CacheMetrics] = []
+        self._start_time = datetime.now(UTC)
+
+    def record(self, metrics: CacheMetrics) -> None:
+        """Record metrics from an API call.
+
+        Args:
+            metrics: Cache metrics from the call.
+        """
+        self._metrics.append(metrics)
+        logger.debug(
+            "cache_metrics_recorded",
+            workflow_id=self.workflow_id,
+            agent_name=metrics.agent_name,
+            cache_hit=metrics.is_cache_hit,
+            cache_creation=metrics.is_cache_creation,
+            hit_rate=f"{metrics.cache_hit_rate:.1%}",
+        )
+
+    def get_summary(self) -> dict[str, Any]:
+        """Get aggregated summary of all recorded metrics.
+
+        Returns:
+            Dictionary with aggregate statistics.
+        """
+        if not self._metrics:
+            return {
+                "call_count": 0,
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+                "total_cache_creation_tokens": 0,
+                "total_cache_read_tokens": 0,
+                "overall_cache_hit_rate": 0.0,
+                "overall_savings_percent": 0.0,
+                "cache_hits": 0,
+                "cache_misses": 0,
+            }
+
+        total_input = sum(m.input_tokens for m in self._metrics)
+        total_output = sum(m.output_tokens for m in self._metrics)
+        total_cache_creation = sum(m.cache_creation_tokens for m in self._metrics)
+        total_cache_read = sum(m.cache_read_tokens for m in self._metrics)
+
+        # Overall hit rate across all calls
+        total_all_input = total_input + total_cache_read
+        overall_hit_rate = total_cache_read / total_all_input if total_all_input > 0 else 0.0
+
+        # Overall savings
+        uncached_cost = total_all_input
+        cached_cost = (
+            total_input
+            + (total_cache_read * CACHE_READ_COST_MULTIPLIER)
+            + (total_cache_creation * CACHE_WRITE_COST_MULTIPLIER)
+        )
+        overall_savings = (
+            (uncached_cost - cached_cost) / uncached_cost * 100
+            if uncached_cost > 0
+            else 0.0
+        )
+
+        cache_hits = sum(1 for m in self._metrics if m.is_cache_hit)
+        cache_misses = len(self._metrics) - cache_hits
+
+        return {
+            "call_count": len(self._metrics),
+            "total_input_tokens": total_input,
+            "total_output_tokens": total_output,
+            "total_cache_creation_tokens": total_cache_creation,
+            "total_cache_read_tokens": total_cache_read,
+            "overall_cache_hit_rate": round(overall_hit_rate, 4),
+            "overall_savings_percent": round(max(0.0, overall_savings), 2),
+            "cache_hits": cache_hits,
+            "cache_misses": cache_misses,
+            "by_agent": self._get_by_agent_summary(),
+            "workflow_id": self.workflow_id,
+            "duration_seconds": (datetime.now(UTC) - self._start_time).total_seconds(),
+        }
+
+    def _get_by_agent_summary(self) -> dict[str, dict[str, Any]]:
+        """Get summary broken down by agent.
+
+        Returns:
+            Dictionary mapping agent names to their metrics.
+        """
+        by_agent: dict[str, list[CacheMetrics]] = {}
+        for m in self._metrics:
+            agent = m.agent_name or "unknown"
+            if agent not in by_agent:
+                by_agent[agent] = []
+            by_agent[agent].append(m)
+
+        result = {}
+        for agent, metrics in by_agent.items():
+            total_input = sum(m.input_tokens for m in metrics)
+            total_cache_read = sum(m.cache_read_tokens for m in metrics)
+            total_all = total_input + total_cache_read
+
+            result[agent] = {
+                "call_count": len(metrics),
+                "total_input_tokens": total_input,
+                "cache_read_tokens": total_cache_read,
+                "cache_hit_rate": round(total_cache_read / total_all, 4) if total_all > 0 else 0.0,
+                "cache_hits": sum(1 for m in metrics if m.is_cache_hit),
+            }
+
+        return result
+
+    def report_to_langfuse(self) -> None:
+        """Report aggregated metrics to Langfuse.
+
+        Creates a score in Langfuse with cache performance metrics.
+        """
+        try:
+            summary = self.get_summary()
+
+            client = get_client()
+
+            # Report cache hit rate as a score
+            if self.session_id:
+                client.score(
+                    trace_id=self.session_id,
+                    name="cache_hit_rate",
+                    value=summary["overall_cache_hit_rate"],
+                    comment=f"Cache hits: {summary['cache_hits']}/{summary['call_count']}",
+                )
+
+                client.score(
+                    trace_id=self.session_id,
+                    name="cache_savings_percent",
+                    value=summary["overall_savings_percent"],
+                    comment="Estimated cost savings from prompt caching",
+                )
+
+            logger.info(
+                "cache_metrics_reported_to_langfuse",
+                workflow_id=self.workflow_id,
+                session_id=self.session_id,
+                hit_rate=f"{summary['overall_cache_hit_rate']:.1%}",
+                savings=f"{summary['overall_savings_percent']:.1f}%",
+            )
+
+        except Exception as e:
+            logger.warning(
+                "langfuse_report_failed",
+                error=str(e),
+                workflow_id=self.workflow_id,
+            )
+
+    def clear(self) -> None:
+        """Clear all recorded metrics."""
+        self._metrics = []
+        self._start_time = datetime.now(UTC)
+        logger.debug("cache_metrics_cleared", workflow_id=self.workflow_id)

--- a/src/caching/observability.py
+++ b/src/caching/observability.py
@@ -1,0 +1,241 @@
+"""Observability integration for prompt caching.
+
+This module provides integration between cache metrics and Langfuse
+for monitoring cache performance in production.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+from langfuse import get_client
+
+from src.caching.metrics import CacheMetrics, CacheMetricsCollector
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class CacheObservabilityConfig:
+    """Configuration for cache observability.
+
+    Attributes:
+        alert_on_low_hit_rate: Trigger alert when hit rate falls below threshold.
+        low_hit_rate_threshold: Minimum acceptable hit rate (0-1).
+        track_by_agent: Whether to track metrics per agent.
+        track_by_model: Whether to track metrics per model.
+    """
+
+    alert_on_low_hit_rate: bool = True
+    low_hit_rate_threshold: float = 0.8
+    track_by_agent: bool = True
+    track_by_model: bool = True
+
+
+class CacheObservabilityReporter:
+    """Reports cache metrics to Langfuse for observability.
+
+    Integrates with Langfuse to provide:
+    - Cache hit rate tracking per request
+    - Cost savings estimation
+    - Alerts for low cache hit rates
+    - Per-agent cache performance breakdown
+
+    Example:
+        reporter = CacheObservabilityReporter(trace_id="trace-123")
+
+        # During workflow execution
+        metrics = CacheMetrics.from_response(response, agent_name="research")
+        reporter.record(metrics)
+
+        # At end of workflow
+        reporter.report_summary()
+    """
+
+    def __init__(
+        self,
+        trace_id: str,
+        *,
+        session_id: str | None = None,
+        config: CacheObservabilityConfig | None = None,
+    ) -> None:
+        """Initialize the reporter.
+
+        Args:
+            trace_id: Langfuse trace ID for the current request.
+            session_id: Optional session ID for grouping.
+            config: Optional configuration overrides.
+        """
+        self.trace_id = trace_id
+        self.session_id = session_id
+        self.config = config or CacheObservabilityConfig()
+        self._collector = CacheMetricsCollector(
+            workflow_id=trace_id,
+            session_id=session_id,
+        )
+
+    def record(self, metrics: CacheMetrics) -> None:
+        """Record metrics from an API call.
+
+        Args:
+            metrics: Cache metrics from the call.
+        """
+        self._collector.record(metrics)
+
+        # Report individual call metrics to Langfuse
+        self._report_call_metrics(metrics)
+
+    def _report_call_metrics(self, metrics: CacheMetrics) -> None:
+        """Report metrics from a single API call to Langfuse.
+
+        Args:
+            metrics: Cache metrics to report.
+        """
+        try:
+            client = get_client()
+
+            # Create a span for the cache metrics
+            span = client.span(
+                trace_id=self.trace_id,
+                name=f"cache_metrics_{metrics.agent_name}",
+                metadata={
+                    "cache_hit": metrics.is_cache_hit,
+                    "cache_creation": metrics.is_cache_creation,
+                    "input_tokens": metrics.input_tokens,
+                    "cache_read_tokens": metrics.cache_read_tokens,
+                    "cache_creation_tokens": metrics.cache_creation_tokens,
+                    "cache_hit_rate": metrics.cache_hit_rate,
+                    "estimated_savings_percent": metrics.estimated_savings_percent,
+                    "agent_name": metrics.agent_name,
+                    "model": metrics.model,
+                },
+            )
+            span.end()
+
+            logger.debug(
+                "cache_call_metrics_reported",
+                trace_id=self.trace_id,
+                agent=metrics.agent_name,
+                hit_rate=f"{metrics.cache_hit_rate:.1%}",
+            )
+
+        except Exception as e:
+            logger.warning(
+                "cache_call_metrics_report_failed",
+                trace_id=self.trace_id,
+                error=str(e),
+            )
+
+    def report_summary(self) -> dict[str, Any]:
+        """Report aggregated metrics summary to Langfuse.
+
+        Returns:
+            Summary dictionary of cache metrics.
+        """
+        summary = self._collector.get_summary()
+
+        try:
+            client = get_client()
+
+            # Report cache hit rate as a score
+            client.score(
+                trace_id=self.trace_id,
+                name="cache_hit_rate",
+                value=summary["overall_cache_hit_rate"],
+                comment=f"Cache hits: {summary['cache_hits']}/{summary['call_count']} calls",
+            )
+
+            # Report cost savings as a score
+            client.score(
+                trace_id=self.trace_id,
+                name="cache_cost_savings",
+                value=summary["overall_savings_percent"] / 100,  # Normalize to 0-1
+                comment=f"Estimated {summary['overall_savings_percent']:.1f}% cost reduction",
+            )
+
+            # Check for low hit rate alert
+            if (
+                self.config.alert_on_low_hit_rate
+                and summary["overall_cache_hit_rate"] < self.config.low_hit_rate_threshold
+            ):
+                logger.warning(
+                    "low_cache_hit_rate_alert",
+                    trace_id=self.trace_id,
+                    hit_rate=summary["overall_cache_hit_rate"],
+                    threshold=self.config.low_hit_rate_threshold,
+                )
+
+                # Add event for alert
+                client.trace_update(
+                    trace_id=self.trace_id,
+                    metadata={
+                        "alert": "low_cache_hit_rate",
+                        "cache_hit_rate": summary["overall_cache_hit_rate"],
+                        "threshold": self.config.low_hit_rate_threshold,
+                    },
+                )
+
+            # Report per-agent breakdown if configured
+            if self.config.track_by_agent and summary.get("by_agent"):
+                for agent_name, agent_metrics in summary["by_agent"].items():
+                    client.score(
+                        trace_id=self.trace_id,
+                        name=f"cache_hit_rate_{agent_name}",
+                        value=agent_metrics["cache_hit_rate"],
+                        comment=f"{agent_name}: {agent_metrics['cache_hits']} cache hits",
+                    )
+
+            logger.info(
+                "cache_summary_reported",
+                trace_id=self.trace_id,
+                hit_rate=f"{summary['overall_cache_hit_rate']:.1%}",
+                savings=f"{summary['overall_savings_percent']:.1f}%",
+                calls=summary["call_count"],
+            )
+
+        except Exception as e:
+            logger.warning(
+                "cache_summary_report_failed",
+                trace_id=self.trace_id,
+                error=str(e),
+            )
+
+        return summary
+
+    def get_metrics_for_state(self) -> dict[str, Any]:
+        """Get cache metrics suitable for storing in workflow state.
+
+        Returns:
+            Dictionary of cache metrics for state storage.
+        """
+        summary = self._collector.get_summary()
+        return {
+            "overall_cache_hit_rate": summary["overall_cache_hit_rate"],
+            "overall_savings_percent": summary["overall_savings_percent"],
+            "total_cache_read_tokens": summary["total_cache_read_tokens"],
+            "total_cache_creation_tokens": summary["total_cache_creation_tokens"],
+            "cache_hits": summary["cache_hits"],
+            "cache_misses": summary["cache_misses"],
+            "by_agent": summary.get("by_agent", {}),
+        }
+
+
+def create_cache_reporter(
+    trace_id: str,
+    session_id: str | None = None,
+) -> CacheObservabilityReporter:
+    """Create a cache observability reporter.
+
+    Convenience function for creating a reporter with default config.
+
+    Args:
+        trace_id: Langfuse trace ID.
+        session_id: Optional session ID.
+
+    Returns:
+        Configured CacheObservabilityReporter.
+    """
+    return CacheObservabilityReporter(
+        trace_id=trace_id,
+        session_id=session_id,
+    )

--- a/src/caching/prompt_cache.py
+++ b/src/caching/prompt_cache.py
@@ -1,0 +1,376 @@
+"""Prompt caching utilities for Claude API.
+
+This module provides utilities for structuring prompts to take advantage
+of Claude's prompt caching feature, which can reduce costs by up to 90%
+and latency by up to 85% for repeated content.
+
+Cache Control:
+    - "ephemeral": 5-minute TTL (default), refreshes on hit
+    - Content must be at least 1,024 tokens to be cached
+
+Usage:
+    # Build cached system prompt
+    system = build_cached_system_prompt(
+        agent_prompt="You are a research agent...",
+        tool_definitions=tools,
+    )
+
+    # Use with Anthropic API
+    response = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        system=system,
+        messages=messages,
+    )
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+class CacheControlType(str, Enum):
+    """Supported cache control types."""
+
+    EPHEMERAL = "ephemeral"
+
+
+@dataclass
+class CacheControl:
+    """Cache control configuration for a content block.
+
+    Attributes:
+        type: The cache control type (currently only "ephemeral").
+    """
+
+    type: CacheControlType = CacheControlType.EPHEMERAL
+
+    def to_dict(self) -> dict[str, str]:
+        """Convert to API-compatible dictionary.
+
+        Returns:
+            Dictionary with cache_control configuration.
+        """
+        return {"type": self.type.value}
+
+
+@dataclass
+class CacheableContent:
+    """A content block that can be cached.
+
+    Attributes:
+        text: The text content to cache.
+        cache_control: Optional cache control settings.
+    """
+
+    text: str
+    cache_control: CacheControl | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to API-compatible dictionary.
+
+        Returns:
+            Dictionary representation for API calls.
+        """
+        result: dict[str, Any] = {
+            "type": "text",
+            "text": self.text,
+        }
+        if self.cache_control:
+            result["cache_control"] = self.cache_control.to_dict()
+        return result
+
+    @classmethod
+    def cached(cls, text: str) -> "CacheableContent":
+        """Create a cached content block.
+
+        Args:
+            text: The text content to cache.
+
+        Returns:
+            CacheableContent with ephemeral caching enabled.
+        """
+        return cls(text=text, cache_control=CacheControl())
+
+    @classmethod
+    def uncached(cls, text: str) -> "CacheableContent":
+        """Create an uncached content block.
+
+        Args:
+            text: The text content (not cached).
+
+        Returns:
+            CacheableContent without caching.
+        """
+        return cls(text=text, cache_control=None)
+
+
+@dataclass
+class CachedPromptBuilder:
+    """Builder for constructing prompts with optimal cache placement.
+
+    This builder helps structure prompts to maximize cache efficiency
+    by placing static content at the beginning with cache breakpoints.
+
+    Example:
+        builder = CachedPromptBuilder()
+        builder.add_system_prompt(AGENT_PROMPT, cached=True)
+        builder.add_tool_definitions(tools, cached=True)
+        builder.add_context(dynamic_context, cached=False)
+
+        system = builder.build_system()
+    """
+
+    _system_blocks: list[CacheableContent] = field(default_factory=list)
+    _tool_blocks: list[CacheableContent] = field(default_factory=list)
+
+    def add_system_prompt(self, prompt: str, *, cached: bool = True) -> "CachedPromptBuilder":
+        """Add a system prompt block.
+
+        Args:
+            prompt: The system prompt text.
+            cached: Whether to enable caching for this block.
+
+        Returns:
+            Self for method chaining.
+        """
+        if cached:
+            self._system_blocks.append(CacheableContent.cached(prompt))
+        else:
+            self._system_blocks.append(CacheableContent.uncached(prompt))
+
+        logger.debug(
+            "system_prompt_added",
+            length=len(prompt),
+            cached=cached,
+        )
+        return self
+
+    def add_tool_definitions(
+        self,
+        tools: list[dict[str, Any]],
+        *,
+        cached: bool = True,
+    ) -> "CachedPromptBuilder":
+        """Add tool definitions as a cacheable block.
+
+        Args:
+            tools: List of tool definitions in Anthropic format.
+            cached: Whether to enable caching for this block.
+
+        Returns:
+            Self for method chaining.
+        """
+        if not tools:
+            return self
+
+        # Format tools as text block for system prompt
+        # Note: Tools are typically passed separately to the API,
+        # but we can include descriptions in the system prompt for caching
+        tool_text = self._format_tools_for_prompt(tools)
+        if cached:
+            self._tool_blocks.append(CacheableContent.cached(tool_text))
+        else:
+            self._tool_blocks.append(CacheableContent.uncached(tool_text))
+
+        logger.debug(
+            "tool_definitions_added",
+            tool_count=len(tools),
+            cached=cached,
+        )
+        return self
+
+    def add_context(
+        self,
+        context: str,
+        *,
+        label: str | None = None,
+        cached: bool = False,
+    ) -> "CachedPromptBuilder":
+        """Add additional context to the system prompt.
+
+        Args:
+            context: The context text to add.
+            label: Optional label for the context section.
+            cached: Whether to enable caching for this block.
+
+        Returns:
+            Self for method chaining.
+        """
+        text = f"\n\n## {label}\n{context}" if label else f"\n\n{context}"
+
+        if cached:
+            self._system_blocks.append(CacheableContent.cached(text))
+        else:
+            self._system_blocks.append(CacheableContent.uncached(text))
+
+        logger.debug(
+            "context_added",
+            label=label,
+            length=len(context),
+            cached=cached,
+        )
+        return self
+
+    def build_system(self) -> list[dict[str, Any]]:
+        """Build the system parameter for the API call.
+
+        Returns:
+            List of content blocks for the system parameter.
+
+        Note:
+            Claude API accepts system as either a string or list of blocks.
+            Using list format enables cache_control on individual blocks.
+        """
+        blocks = []
+        for content in self._system_blocks:
+            blocks.append(content.to_dict())
+        for content in self._tool_blocks:
+            blocks.append(content.to_dict())
+
+        logger.debug(
+            "system_prompt_built",
+            block_count=len(blocks),
+            cached_count=sum(1 for b in blocks if "cache_control" in b),
+        )
+        return blocks
+
+    def _format_tools_for_prompt(self, tools: list[dict[str, Any]]) -> str:
+        """Format tool definitions for inclusion in system prompt.
+
+        Args:
+            tools: List of tool definitions.
+
+        Returns:
+            Formatted string describing tools.
+        """
+        lines = ["\n## Available Tools\n"]
+        for tool in tools:
+            name = tool.get("name", "unknown")
+            description = tool.get("description", "No description")
+            lines.append(f"- **{name}**: {description}")
+
+            # Include input schema summary if available
+            input_schema = tool.get("input_schema", {})
+            if input_schema.get("properties"):
+                props = input_schema["properties"]
+                param_list = ", ".join(props.keys())
+                lines.append(f"  Parameters: {param_list}")
+
+        return "\n".join(lines)
+
+
+def build_cached_system_prompt(
+    agent_prompt: str,
+    *,
+    tool_definitions: list[dict[str, Any]] | None = None,
+    memory_context: str | None = None,
+    additional_context: str | None = None,
+) -> list[dict[str, Any]]:
+    """Build a cached system prompt with optimal cache placement.
+
+    This is a convenience function for common use cases. For more control,
+    use CachedPromptBuilder directly.
+
+    Args:
+        agent_prompt: The main agent system prompt (cached).
+        tool_definitions: Optional tool definitions (cached).
+        memory_context: Optional memory/history context (cached if stable).
+        additional_context: Optional dynamic context (not cached).
+
+    Returns:
+        List of content blocks for the system parameter.
+
+    Example:
+        system = build_cached_system_prompt(
+            agent_prompt=RESEARCH_AGENT_PROMPT,
+            tool_definitions=tools,
+            additional_context=f"User request: {user_query}"
+        )
+    """
+    builder = CachedPromptBuilder()
+
+    # Add main prompt (always cached - this is the static agent definition)
+    builder.add_system_prompt(agent_prompt, cached=True)
+
+    # Add tool definitions if provided (cached - these are static)
+    if tool_definitions:
+        builder.add_tool_definitions(tool_definitions, cached=True)
+
+    # Add memory context if provided (cached - relatively stable)
+    if memory_context:
+        builder.add_context(memory_context, label="Memory Context", cached=True)
+
+    # Add dynamic context if provided (not cached - changes per request)
+    if additional_context:
+        builder.add_context(additional_context, label="Current Context", cached=False)
+
+    return builder.build_system()
+
+
+def build_cached_tool_definitions(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Add cache control to tool definitions.
+
+    Note: Tool caching is applied at the tool list level, not individual tools.
+    The last tool in the list should have cache_control for optimal caching.
+
+    Args:
+        tools: List of tool definitions in Anthropic format.
+
+    Returns:
+        Tools with cache_control added to the last tool.
+    """
+    if not tools:
+        return tools
+
+    # Clone tools to avoid mutating originals
+    cached_tools = []
+    for i, tool in enumerate(tools):
+        tool_copy = dict(tool)
+        # Add cache_control to the last tool
+        if i == len(tools) - 1:
+            tool_copy["cache_control"] = {"type": "ephemeral"}
+        cached_tools.append(tool_copy)
+
+    logger.debug(
+        "tools_cached",
+        tool_count=len(cached_tools),
+    )
+    return cached_tools
+
+
+def estimate_cache_tokens(text: str) -> int:
+    """Estimate the number of tokens in text for cache planning.
+
+    This is a rough estimate based on average token length.
+    Actual token count may vary by ~20%.
+
+    Args:
+        text: Text to estimate tokens for.
+
+    Returns:
+        Estimated token count.
+
+    Note:
+        Claude requires at least 1,024 tokens per cache checkpoint.
+    """
+    # Rough estimate: ~4 characters per token on average
+    estimated = len(text) // 4
+    logger.debug("tokens_estimated", text_length=len(text), estimated_tokens=estimated)
+    return estimated
+
+
+def is_cacheable(text: str, min_tokens: int = 1024) -> bool:
+    """Check if text meets minimum token requirement for caching.
+
+    Args:
+        text: Text to check.
+        min_tokens: Minimum tokens required (default 1024).
+
+    Returns:
+        True if text is long enough to be cached.
+    """
+    return estimate_cache_tokens(text) >= min_tokens

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,82 @@
+"""Application configuration settings.
+
+This module provides centralized configuration management using environment
+variables with sensible defaults.
+"""
+
+import os
+from dataclasses import dataclass
+
+
+def _get_bool_env(name: str, default: bool = False) -> bool:
+    """Get a boolean value from environment variable.
+
+    Args:
+        name: Environment variable name.
+        default: Default value if not set.
+
+    Returns:
+        Boolean value from environment.
+    """
+    value = os.getenv(name, "").lower()
+    if value in ("true", "1", "yes", "on"):
+        return True
+    if value in ("false", "0", "no", "off"):
+        return False
+    return default
+
+
+@dataclass
+class Settings:
+    """Application settings loaded from environment variables.
+
+    Attributes:
+        USE_PROMPT_CACHING: Enable Claude prompt caching for cost reduction.
+        LANGFUSE_HOST: Langfuse server host URL.
+        LANGFUSE_PUBLIC_KEY: Langfuse public API key.
+        LANGFUSE_SECRET_KEY: Langfuse secret API key.
+        POLYGON_API_KEY: Polygon.io API key for market data.
+        REDIS_URL: Redis connection URL for caching.
+        DEFAULT_MODEL: Default Claude model to use.
+        LOG_LEVEL: Logging level.
+    """
+
+    # Prompt caching
+    USE_PROMPT_CACHING: bool = True  # Default to enabled for cost savings
+
+    # Observability
+    LANGFUSE_HOST: str = "http://localhost:3000"
+    LANGFUSE_PUBLIC_KEY: str | None = None
+    LANGFUSE_SECRET_KEY: str | None = None
+
+    # Data sources
+    POLYGON_API_KEY: str | None = None
+    REDIS_URL: str = "redis://localhost:6379"
+
+    # Model settings
+    DEFAULT_MODEL: str = "claude-sonnet-4-20250514"
+
+    # Logging
+    LOG_LEVEL: str = "INFO"
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        """Create settings from environment variables.
+
+        Returns:
+            Settings instance populated from environment.
+        """
+        return cls(
+            USE_PROMPT_CACHING=_get_bool_env("USE_PROMPT_CACHING", default=True),
+            LANGFUSE_HOST=os.getenv("LANGFUSE_HOST", "http://localhost:3000"),
+            LANGFUSE_PUBLIC_KEY=os.getenv("LANGFUSE_PUBLIC_KEY"),
+            LANGFUSE_SECRET_KEY=os.getenv("LANGFUSE_SECRET_KEY"),
+            POLYGON_API_KEY=os.getenv("POLYGON_API_KEY"),
+            REDIS_URL=os.getenv("REDIS_URL", "redis://localhost:6379"),
+            DEFAULT_MODEL=os.getenv("DEFAULT_MODEL", "claude-sonnet-4-20250514"),
+            LOG_LEVEL=os.getenv("LOG_LEVEL", "INFO"),
+        )
+
+
+# Global settings instance
+settings = Settings.from_env()

--- a/src/orchestration/state.py
+++ b/src/orchestration/state.py
@@ -192,6 +192,9 @@ class PortfolioState(TypedDict, total=False):
     # Context for passing additional data
     context: dict[str, Any]
 
+    # Cache metrics (if prompt caching is enabled)
+    cache_metrics: dict[str, Any] | None
+
 
 # ============================================================================
 # State Factory and Helpers
@@ -244,6 +247,7 @@ def create_initial_state(
         "messages": [],
         "errors": [],
         "context": {},
+        "cache_metrics": None,
     }
 
     logger.info(

--- a/tests/test_caching/__init__.py
+++ b/tests/test_caching/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the prompt caching module."""

--- a/tests/test_caching/test_metrics.py
+++ b/tests/test_caching/test_metrics.py
@@ -1,0 +1,357 @@
+"""Tests for cache metrics tracking."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from src.caching.metrics import (
+    CACHE_READ_COST_MULTIPLIER,
+    CACHE_WRITE_COST_MULTIPLIER,
+    CacheMetrics,
+    CacheMetricsCollector,
+)
+
+
+class TestCacheMetrics:
+    """Tests for CacheMetrics dataclass."""
+
+    def test_default_values(self):
+        """Default values should be zero/empty."""
+        metrics = CacheMetrics()
+        assert metrics.input_tokens == 0
+        assert metrics.output_tokens == 0
+        assert metrics.cache_creation_tokens == 0
+        assert metrics.cache_read_tokens == 0
+        assert metrics.model == ""
+        assert metrics.agent_name == ""
+        assert isinstance(metrics.timestamp, datetime)
+
+    def test_total_input_tokens(self):
+        """total_input_tokens should sum regular and cached."""
+        metrics = CacheMetrics(input_tokens=100, cache_read_tokens=500)
+        assert metrics.total_input_tokens == 600
+
+    def test_cache_hit_rate_with_hits(self):
+        """cache_hit_rate should calculate correctly."""
+        metrics = CacheMetrics(input_tokens=200, cache_read_tokens=800)
+        # 800 / (200 + 800) = 0.8
+        assert metrics.cache_hit_rate == 0.8
+
+    def test_cache_hit_rate_no_cached(self):
+        """cache_hit_rate should be 0 when no cached tokens."""
+        metrics = CacheMetrics(input_tokens=100, cache_read_tokens=0)
+        assert metrics.cache_hit_rate == 0.0
+
+    def test_cache_hit_rate_zero_total(self):
+        """cache_hit_rate should be 0 when no input tokens."""
+        metrics = CacheMetrics(input_tokens=0, cache_read_tokens=0)
+        assert metrics.cache_hit_rate == 0.0
+
+    def test_estimated_savings_percent_with_cache(self):
+        """estimated_savings_percent should calculate correctly."""
+        # 100 regular + 900 cached = 1000 total
+        # Uncached cost = 1000
+        # Cached cost = 100 + (900 * 0.1) + (0 * 1.25) = 190
+        # Savings = (1000 - 190) / 1000 * 100 = 81%
+        metrics = CacheMetrics(input_tokens=100, cache_read_tokens=900)
+        assert 80 <= metrics.estimated_savings_percent <= 82
+
+    def test_estimated_savings_percent_no_cache(self):
+        """estimated_savings_percent should be 0 without cache hits."""
+        metrics = CacheMetrics(input_tokens=100, cache_read_tokens=0)
+        assert metrics.estimated_savings_percent == 0.0
+
+    def test_estimated_savings_with_creation(self):
+        """estimated_savings_percent accounts for cache creation cost."""
+        # First call: creates cache (more expensive)
+        metrics = CacheMetrics(
+            input_tokens=100,
+            cache_read_tokens=0,
+            cache_creation_tokens=500,
+        )
+        # No savings on cache miss
+        assert metrics.estimated_savings_percent == 0.0
+
+    def test_is_cache_hit_true(self):
+        """is_cache_hit should be True when cache_read_tokens > 0."""
+        metrics = CacheMetrics(cache_read_tokens=100)
+        assert metrics.is_cache_hit is True
+
+    def test_is_cache_hit_false(self):
+        """is_cache_hit should be False when no cache reads."""
+        metrics = CacheMetrics(cache_read_tokens=0)
+        assert metrics.is_cache_hit is False
+
+    def test_is_cache_creation_true(self):
+        """is_cache_creation should be True when cache created."""
+        metrics = CacheMetrics(cache_creation_tokens=100)
+        assert metrics.is_cache_creation is True
+
+    def test_is_cache_creation_false(self):
+        """is_cache_creation should be False when no creation."""
+        metrics = CacheMetrics(cache_creation_tokens=0)
+        assert metrics.is_cache_creation is False
+
+    def test_to_dict(self):
+        """to_dict should return all relevant fields."""
+        metrics = CacheMetrics(
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_tokens=0,
+            cache_read_tokens=400,
+            model="claude-3-sonnet",
+            agent_name="research",
+        )
+        result = metrics.to_dict()
+
+        assert result["input_tokens"] == 100
+        assert result["output_tokens"] == 50
+        assert result["cache_creation_tokens"] == 0
+        assert result["cache_read_tokens"] == 400
+        assert result["total_input_tokens"] == 500
+        assert result["model"] == "claude-3-sonnet"
+        assert result["agent_name"] == "research"
+        assert "cache_hit_rate" in result
+        assert "estimated_savings_percent" in result
+        assert "is_cache_hit" in result
+        assert "is_cache_creation" in result
+        assert "timestamp" in result
+
+    def test_from_response_with_usage(self):
+        """from_response should extract usage data."""
+        mock_response = MagicMock()
+        mock_response.usage = MagicMock(
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_input_tokens=200,
+            cache_read_input_tokens=800,
+        )
+
+        metrics = CacheMetrics.from_response(
+            mock_response,
+            model="claude-3-opus",
+            agent_name="analysis",
+        )
+
+        assert metrics.input_tokens == 100
+        assert metrics.output_tokens == 50
+        assert metrics.cache_creation_tokens == 200
+        assert metrics.cache_read_tokens == 800
+        assert metrics.model == "claude-3-opus"
+        assert metrics.agent_name == "analysis"
+
+    def test_from_response_no_usage(self):
+        """from_response should handle missing usage."""
+        mock_response = MagicMock(spec=[])
+
+        metrics = CacheMetrics.from_response(
+            mock_response,
+            model="claude-3-sonnet",
+            agent_name="test",
+        )
+
+        assert metrics.input_tokens == 0
+        assert metrics.output_tokens == 0
+        assert metrics.model == "claude-3-sonnet"
+        assert metrics.agent_name == "test"
+
+    def test_from_usage_dict(self):
+        """from_usage_dict should extract from dictionary."""
+        usage = {
+            "input_tokens": 150,
+            "output_tokens": 75,
+            "cache_creation_input_tokens": 300,
+            "cache_read_input_tokens": 600,
+        }
+
+        metrics = CacheMetrics.from_usage_dict(
+            usage,
+            model="claude-3-haiku",
+            agent_name="synthesis",
+        )
+
+        assert metrics.input_tokens == 150
+        assert metrics.output_tokens == 75
+        assert metrics.cache_creation_tokens == 300
+        assert metrics.cache_read_tokens == 600
+        assert metrics.model == "claude-3-haiku"
+        assert metrics.agent_name == "synthesis"
+
+    def test_from_usage_dict_missing_keys(self):
+        """from_usage_dict should handle missing keys."""
+        usage = {"input_tokens": 100}
+
+        metrics = CacheMetrics.from_usage_dict(usage)
+
+        assert metrics.input_tokens == 100
+        assert metrics.output_tokens == 0
+        assert metrics.cache_creation_tokens == 0
+        assert metrics.cache_read_tokens == 0
+
+
+class TestCacheMetricsCollector:
+    """Tests for CacheMetricsCollector class."""
+
+    def test_initialization(self):
+        """Collector should initialize properly."""
+        collector = CacheMetricsCollector(
+            workflow_id="wf-123",
+            session_id="sess-456",
+        )
+        assert collector.workflow_id == "wf-123"
+        assert collector.session_id == "sess-456"
+
+    def test_record_metrics(self):
+        """record should add metrics to the list."""
+        collector = CacheMetricsCollector()
+        metrics = CacheMetrics(input_tokens=100, cache_read_tokens=400)
+        collector.record(metrics)
+
+        summary = collector.get_summary()
+        assert summary["call_count"] == 1
+
+    def test_get_summary_empty(self):
+        """get_summary should return zeros when empty."""
+        collector = CacheMetricsCollector()
+        summary = collector.get_summary()
+
+        assert summary["call_count"] == 0
+        assert summary["total_input_tokens"] == 0
+        assert summary["overall_cache_hit_rate"] == 0.0
+        assert summary["cache_hits"] == 0
+        assert summary["cache_misses"] == 0
+
+    def test_get_summary_aggregates(self):
+        """get_summary should aggregate multiple calls."""
+        collector = CacheMetricsCollector(workflow_id="test-wf")
+
+        # First call: cache miss (creation)
+        collector.record(
+            CacheMetrics(
+                input_tokens=500,
+                output_tokens=100,
+                cache_creation_tokens=500,
+                cache_read_tokens=0,
+                agent_name="research",
+            )
+        )
+
+        # Second call: cache hit
+        collector.record(
+            CacheMetrics(
+                input_tokens=100,
+                output_tokens=150,
+                cache_read_tokens=400,
+                agent_name="research",
+            )
+        )
+
+        summary = collector.get_summary()
+
+        assert summary["call_count"] == 2
+        assert summary["total_input_tokens"] == 600  # 500 + 100
+        assert summary["total_output_tokens"] == 250  # 100 + 150
+        assert summary["total_cache_creation_tokens"] == 500
+        assert summary["total_cache_read_tokens"] == 400
+        assert summary["cache_hits"] == 1
+        assert summary["cache_misses"] == 1
+        assert summary["workflow_id"] == "test-wf"
+
+    def test_get_summary_overall_hit_rate(self):
+        """overall_cache_hit_rate should be calculated correctly."""
+        collector = CacheMetricsCollector()
+
+        # Add metrics with known hit rate
+        collector.record(CacheMetrics(input_tokens=200, cache_read_tokens=800))
+
+        summary = collector.get_summary()
+        # 800 / (200 + 800) = 0.8
+        assert summary["overall_cache_hit_rate"] == 0.8
+
+    def test_by_agent_summary(self):
+        """Summary should include per-agent breakdown."""
+        collector = CacheMetricsCollector()
+
+        collector.record(
+            CacheMetrics(input_tokens=100, cache_read_tokens=400, agent_name="agent1")
+        )
+        collector.record(
+            CacheMetrics(input_tokens=200, cache_read_tokens=300, agent_name="agent2")
+        )
+
+        summary = collector.get_summary()
+
+        assert "by_agent" in summary
+        assert "agent1" in summary["by_agent"]
+        assert "agent2" in summary["by_agent"]
+        assert summary["by_agent"]["agent1"]["call_count"] == 1
+        assert summary["by_agent"]["agent2"]["call_count"] == 1
+
+    def test_by_agent_unknown(self):
+        """Metrics without agent_name should be grouped as unknown."""
+        collector = CacheMetricsCollector()
+        collector.record(CacheMetrics(input_tokens=100))
+
+        summary = collector.get_summary()
+
+        assert "unknown" in summary["by_agent"]
+
+    def test_clear(self):
+        """clear should reset all metrics."""
+        collector = CacheMetricsCollector()
+        collector.record(CacheMetrics(input_tokens=100))
+        collector.clear()
+
+        summary = collector.get_summary()
+        assert summary["call_count"] == 0
+
+    @patch("src.caching.metrics.get_client")
+    def test_report_to_langfuse(self, mock_get_client):
+        """report_to_langfuse should call Langfuse client."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        collector = CacheMetricsCollector(
+            workflow_id="wf-123",
+            session_id="sess-456",
+        )
+        collector.record(CacheMetrics(input_tokens=100, cache_read_tokens=400))
+        collector.report_to_langfuse()
+
+        # Should call score at least once
+        mock_client.score.assert_called()
+
+    @patch("src.caching.metrics.get_client")
+    def test_report_to_langfuse_no_session(self, mock_get_client):
+        """report_to_langfuse should handle missing session_id."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        collector = CacheMetricsCollector(workflow_id="wf-123")
+        collector.record(CacheMetrics(input_tokens=100))
+        collector.report_to_langfuse()
+
+        # Should not fail
+        mock_client.score.assert_not_called()
+
+    @patch("src.caching.metrics.get_client")
+    def test_report_to_langfuse_error_handling(self, mock_get_client):
+        """report_to_langfuse should handle errors gracefully."""
+        mock_get_client.side_effect = Exception("Connection failed")
+
+        collector = CacheMetricsCollector(session_id="sess-123")
+        collector.record(CacheMetrics(input_tokens=100))
+
+        # Should not raise
+        collector.report_to_langfuse()
+
+
+class TestCostConstants:
+    """Tests for cost multiplier constants."""
+
+    def test_cache_read_cost_multiplier(self):
+        """Cache read should be 10% of base cost."""
+        assert CACHE_READ_COST_MULTIPLIER == 0.10
+
+    def test_cache_write_cost_multiplier(self):
+        """Cache write should be 125% of base cost."""
+        assert CACHE_WRITE_COST_MULTIPLIER == 1.25

--- a/tests/test_caching/test_observability.py
+++ b/tests/test_caching/test_observability.py
@@ -1,0 +1,231 @@
+"""Tests for cache observability integration."""
+
+from unittest.mock import MagicMock, patch
+
+from src.caching.metrics import CacheMetrics
+from src.caching.observability import (
+    CacheObservabilityConfig,
+    CacheObservabilityReporter,
+    create_cache_reporter,
+)
+
+
+class TestCacheObservabilityConfig:
+    """Tests for CacheObservabilityConfig."""
+
+    def test_default_values(self):
+        """Default config values should be sensible."""
+        config = CacheObservabilityConfig()
+        assert config.alert_on_low_hit_rate is True
+        assert config.low_hit_rate_threshold == 0.8
+        assert config.track_by_agent is True
+        assert config.track_by_model is True
+
+    def test_custom_values(self):
+        """Custom config values should be applied."""
+        config = CacheObservabilityConfig(
+            alert_on_low_hit_rate=False,
+            low_hit_rate_threshold=0.5,
+            track_by_agent=False,
+            track_by_model=False,
+        )
+        assert config.alert_on_low_hit_rate is False
+        assert config.low_hit_rate_threshold == 0.5
+        assert config.track_by_agent is False
+        assert config.track_by_model is False
+
+
+class TestCacheObservabilityReporter:
+    """Tests for CacheObservabilityReporter."""
+
+    def test_initialization(self):
+        """Reporter should initialize with correct values."""
+        reporter = CacheObservabilityReporter(
+            trace_id="trace-123",
+            session_id="sess-456",
+        )
+        assert reporter.trace_id == "trace-123"
+        assert reporter.session_id == "sess-456"
+        assert reporter.config is not None
+
+    def test_initialization_with_config(self):
+        """Reporter should accept custom config."""
+        config = CacheObservabilityConfig(low_hit_rate_threshold=0.5)
+        reporter = CacheObservabilityReporter(
+            trace_id="trace-123",
+            config=config,
+        )
+        assert reporter.config.low_hit_rate_threshold == 0.5
+
+    @patch("src.caching.observability.get_client")
+    def test_record_metrics(self, mock_get_client):
+        """record should add metrics and report to Langfuse."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        reporter = CacheObservabilityReporter(trace_id="trace-123")
+        metrics = CacheMetrics(
+            input_tokens=100,
+            cache_read_tokens=400,
+            agent_name="research",
+        )
+        reporter.record(metrics)
+
+        # Should create a span for the metrics
+        mock_client.span.assert_called_once()
+        span_kwargs = mock_client.span.call_args.kwargs
+        assert span_kwargs["trace_id"] == "trace-123"
+        assert "research" in span_kwargs["name"]
+
+    @patch("src.caching.observability.get_client")
+    def test_record_metrics_error_handling(self, mock_get_client):
+        """record should handle Langfuse errors gracefully."""
+        mock_get_client.side_effect = Exception("Connection failed")
+
+        reporter = CacheObservabilityReporter(trace_id="trace-123")
+        metrics = CacheMetrics(input_tokens=100)
+
+        # Should not raise
+        reporter.record(metrics)
+
+    @patch("src.caching.observability.get_client")
+    def test_report_summary(self, mock_get_client):
+        """report_summary should report aggregated metrics."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        reporter = CacheObservabilityReporter(trace_id="trace-123")
+        reporter.record(CacheMetrics(input_tokens=100, cache_read_tokens=400))
+
+        summary = reporter.report_summary()
+
+        assert "overall_cache_hit_rate" in summary
+        assert "overall_savings_percent" in summary
+        mock_client.score.assert_called()
+
+    @patch("src.caching.observability.get_client")
+    def test_report_summary_low_hit_rate_alert(self, mock_get_client):
+        """report_summary should alert on low hit rate."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        config = CacheObservabilityConfig(
+            alert_on_low_hit_rate=True,
+            low_hit_rate_threshold=0.8,
+        )
+        reporter = CacheObservabilityReporter(
+            trace_id="trace-123",
+            config=config,
+        )
+        # Add metrics with low hit rate (50%)
+        reporter.record(CacheMetrics(input_tokens=500, cache_read_tokens=500))
+
+        reporter.report_summary()
+
+        # Should update trace with alert
+        mock_client.trace_update.assert_called()
+
+    @patch("src.caching.observability.get_client")
+    def test_report_summary_no_alert_above_threshold(self, mock_get_client):
+        """report_summary should not alert when hit rate is above threshold."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        config = CacheObservabilityConfig(
+            alert_on_low_hit_rate=True,
+            low_hit_rate_threshold=0.8,
+        )
+        reporter = CacheObservabilityReporter(
+            trace_id="trace-123",
+            config=config,
+        )
+        # Add metrics with high hit rate (90%)
+        reporter.record(CacheMetrics(input_tokens=100, cache_read_tokens=900))
+
+        reporter.report_summary()
+
+        # Should NOT update trace with alert
+        mock_client.trace_update.assert_not_called()
+
+    @patch("src.caching.observability.get_client")
+    def test_report_summary_per_agent_breakdown(self, mock_get_client):
+        """report_summary should include per-agent breakdown."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        reporter = CacheObservabilityReporter(trace_id="trace-123")
+        reporter.record(
+            CacheMetrics(input_tokens=100, cache_read_tokens=400, agent_name="agent1")
+        )
+        reporter.record(
+            CacheMetrics(input_tokens=200, cache_read_tokens=300, agent_name="agent2")
+        )
+
+        summary = reporter.report_summary()
+
+        assert "by_agent" in summary
+        assert "agent1" in summary["by_agent"]
+        assert "agent2" in summary["by_agent"]
+
+        # Should have multiple score calls for per-agent metrics
+        assert mock_client.score.call_count >= 2
+
+    @patch("src.caching.observability.get_client")
+    def test_report_summary_error_handling(self, mock_get_client):
+        """report_summary should handle errors gracefully."""
+        mock_get_client.side_effect = Exception("Connection failed")
+
+        reporter = CacheObservabilityReporter(trace_id="trace-123")
+        reporter.record(CacheMetrics(input_tokens=100))
+
+        # Should not raise, should return summary
+        summary = reporter.report_summary()
+        assert summary is not None
+
+    def test_get_metrics_for_state(self):
+        """get_metrics_for_state should return state-friendly dict."""
+        reporter = CacheObservabilityReporter(trace_id="trace-123")
+        reporter._collector.record(
+            CacheMetrics(input_tokens=100, cache_read_tokens=400)
+        )
+
+        state_metrics = reporter.get_metrics_for_state()
+
+        assert "overall_cache_hit_rate" in state_metrics
+        assert "overall_savings_percent" in state_metrics
+        assert "total_cache_read_tokens" in state_metrics
+        assert "cache_hits" in state_metrics
+        assert "cache_misses" in state_metrics
+        assert "by_agent" in state_metrics
+
+    def test_get_metrics_for_state_empty(self):
+        """get_metrics_for_state should handle empty collector."""
+        reporter = CacheObservabilityReporter(trace_id="trace-123")
+        state_metrics = reporter.get_metrics_for_state()
+
+        assert state_metrics["overall_cache_hit_rate"] == 0.0
+        assert state_metrics["cache_hits"] == 0
+
+
+class TestCreateCacheReporter:
+    """Tests for create_cache_reporter factory function."""
+
+    def test_creates_reporter(self):
+        """create_cache_reporter should return a reporter."""
+        reporter = create_cache_reporter(trace_id="trace-123")
+        assert isinstance(reporter, CacheObservabilityReporter)
+        assert reporter.trace_id == "trace-123"
+
+    def test_passes_session_id(self):
+        """create_cache_reporter should pass session_id."""
+        reporter = create_cache_reporter(
+            trace_id="trace-123",
+            session_id="sess-456",
+        )
+        assert reporter.session_id == "sess-456"
+
+    def test_default_config(self):
+        """create_cache_reporter should use default config."""
+        reporter = create_cache_reporter(trace_id="trace-123")
+        assert reporter.config.alert_on_low_hit_rate is True
+        assert reporter.config.low_hit_rate_threshold == 0.8

--- a/tests/test_caching/test_prompt_cache.py
+++ b/tests/test_caching/test_prompt_cache.py
@@ -1,0 +1,323 @@
+"""Tests for prompt caching utilities."""
+
+from src.caching.prompt_cache import (
+    CacheableContent,
+    CacheControl,
+    CacheControlType,
+    CachedPromptBuilder,
+    build_cached_system_prompt,
+    build_cached_tool_definitions,
+    estimate_cache_tokens,
+    is_cacheable,
+)
+
+
+class TestCacheControl:
+    """Tests for CacheControl class."""
+
+    def test_default_type_is_ephemeral(self):
+        """CacheControl should default to ephemeral type."""
+        control = CacheControl()
+        assert control.type == CacheControlType.EPHEMERAL
+
+    def test_to_dict(self):
+        """to_dict should return correct format for API."""
+        control = CacheControl()
+        result = control.to_dict()
+        assert result == {"type": "ephemeral"}
+
+    def test_explicit_ephemeral_type(self):
+        """Explicit ephemeral type should work."""
+        control = CacheControl(type=CacheControlType.EPHEMERAL)
+        assert control.to_dict() == {"type": "ephemeral"}
+
+
+class TestCacheableContent:
+    """Tests for CacheableContent class."""
+
+    def test_uncached_content(self):
+        """Uncached content should not have cache_control."""
+        content = CacheableContent.uncached("test text")
+        result = content.to_dict()
+        assert result == {"type": "text", "text": "test text"}
+        assert "cache_control" not in result
+
+    def test_cached_content(self):
+        """Cached content should include cache_control."""
+        content = CacheableContent.cached("test text")
+        result = content.to_dict()
+        assert result == {
+            "type": "text",
+            "text": "test text",
+            "cache_control": {"type": "ephemeral"},
+        }
+
+    def test_manual_cache_control(self):
+        """Manual cache control should be applied."""
+        control = CacheControl()
+        content = CacheableContent(text="test", cache_control=control)
+        result = content.to_dict()
+        assert "cache_control" in result
+        assert result["cache_control"] == {"type": "ephemeral"}
+
+    def test_to_dict_preserves_text(self):
+        """to_dict should preserve the original text."""
+        text = "This is a test prompt with special chars: <>&"
+        content = CacheableContent.cached(text)
+        assert content.to_dict()["text"] == text
+
+
+class TestCachedPromptBuilder:
+    """Tests for CachedPromptBuilder class."""
+
+    def test_empty_builder(self):
+        """Empty builder should return empty list."""
+        builder = CachedPromptBuilder()
+        assert builder.build_system() == []
+
+    def test_add_system_prompt_cached(self):
+        """Adding cached system prompt should work."""
+        builder = CachedPromptBuilder()
+        builder.add_system_prompt("You are a helpful assistant.", cached=True)
+        result = builder.build_system()
+
+        assert len(result) == 1
+        assert result[0]["type"] == "text"
+        assert result[0]["text"] == "You are a helpful assistant."
+        assert "cache_control" in result[0]
+
+    def test_add_system_prompt_uncached(self):
+        """Adding uncached system prompt should work."""
+        builder = CachedPromptBuilder()
+        builder.add_system_prompt("Dynamic content", cached=False)
+        result = builder.build_system()
+
+        assert len(result) == 1
+        assert "cache_control" not in result[0]
+
+    def test_method_chaining(self):
+        """Builder methods should support chaining."""
+        builder = CachedPromptBuilder()
+        result = (
+            builder.add_system_prompt("Base prompt")
+            .add_context("Extra context")
+            .build_system()
+        )
+        assert len(result) == 2
+
+    def test_add_context_with_label(self):
+        """Adding context with label should format correctly."""
+        builder = CachedPromptBuilder()
+        builder.add_context("Some context info", label="Important")
+        result = builder.build_system()
+
+        assert len(result) == 1
+        assert "## Important" in result[0]["text"]
+        assert "Some context info" in result[0]["text"]
+
+    def test_add_tool_definitions(self):
+        """Adding tool definitions should format correctly."""
+        tools = [
+            {"name": "get_data", "description": "Gets data from API"},
+            {"name": "search", "description": "Searches for info"},
+        ]
+        builder = CachedPromptBuilder()
+        builder.add_tool_definitions(tools, cached=True)
+        result = builder.build_system()
+
+        assert len(result) == 1
+        assert "get_data" in result[0]["text"]
+        assert "search" in result[0]["text"]
+        assert "cache_control" in result[0]
+
+    def test_empty_tools_not_added(self):
+        """Empty tool list should not add a block."""
+        builder = CachedPromptBuilder()
+        builder.add_tool_definitions([], cached=True)
+        result = builder.build_system()
+        assert len(result) == 0
+
+    def test_full_builder_flow(self):
+        """Full builder flow with all components."""
+        tools = [{"name": "tool1", "description": "A tool"}]
+        builder = CachedPromptBuilder()
+        result = (
+            builder.add_system_prompt("Base prompt", cached=True)
+            .add_tool_definitions(tools, cached=True)
+            .add_context("Memory info", label="Memory", cached=True)
+            .add_context("Dynamic query", label="Query", cached=False)
+            .build_system()
+        )
+
+        assert len(result) == 4
+        # Order: system_blocks first (prompt, memory, query), then tool_blocks
+        # result[0] = Base prompt (cached)
+        # result[1] = Memory info (cached)
+        # result[2] = Dynamic query (uncached)
+        # result[3] = tools (cached)
+        assert "cache_control" in result[0]  # Base prompt
+        assert "cache_control" in result[1]  # Memory
+        assert "cache_control" not in result[2]  # Dynamic query
+        assert "cache_control" in result[3]  # Tools
+
+
+class TestBuildCachedSystemPrompt:
+    """Tests for build_cached_system_prompt function."""
+
+    def test_basic_prompt_only(self):
+        """Basic prompt should be cached."""
+        result = build_cached_system_prompt(agent_prompt="You are helpful.")
+
+        assert len(result) == 1
+        assert result[0]["text"] == "You are helpful."
+        assert "cache_control" in result[0]
+
+    def test_with_tools(self):
+        """Prompt with tools should include both."""
+        tools = [{"name": "search", "description": "Search tool"}]
+        result = build_cached_system_prompt(
+            agent_prompt="You are helpful.",
+            tool_definitions=tools,
+        )
+
+        assert len(result) == 2
+        assert "cache_control" in result[0]
+        assert "cache_control" in result[1]
+
+    def test_with_memory_context(self):
+        """Memory context should be cached."""
+        result = build_cached_system_prompt(
+            agent_prompt="You are helpful.",
+            memory_context="Previous interaction data",
+        )
+
+        assert len(result) == 2
+        assert "Memory Context" in result[1]["text"]
+        assert "cache_control" in result[1]
+
+    def test_with_additional_context(self):
+        """Additional context should not be cached."""
+        result = build_cached_system_prompt(
+            agent_prompt="You are helpful.",
+            additional_context="User query: test",
+        )
+
+        assert len(result) == 2
+        assert "cache_control" in result[0]
+        assert "cache_control" not in result[1]
+
+    def test_full_combination(self):
+        """Full combination of all options."""
+        tools = [{"name": "t1", "description": "d1"}]
+        result = build_cached_system_prompt(
+            agent_prompt="Base",
+            tool_definitions=tools,
+            memory_context="Memory",
+            additional_context="Dynamic",
+        )
+
+        assert len(result) == 4
+        # Order in build_cached_system_prompt:
+        # 1. agent_prompt (cached)
+        # 2. tool_definitions (cached) - added to tool_blocks
+        # 3. memory_context (cached)
+        # 4. additional_context (uncached)
+        # But system_blocks come first, then tool_blocks
+        # result[0] = Base (system prompt, cached)
+        # result[1] = Memory Context (cached)
+        # result[2] = Current Context (uncached)
+        # result[3] = tools (cached)
+        assert "cache_control" in result[0]  # Base
+        assert "cache_control" in result[1]  # Memory
+        assert "cache_control" not in result[2]  # Dynamic
+        assert "cache_control" in result[3]  # Tools
+
+
+class TestBuildCachedToolDefinitions:
+    """Tests for build_cached_tool_definitions function."""
+
+    def test_empty_tools(self):
+        """Empty tools list should return empty list."""
+        result = build_cached_tool_definitions([])
+        assert result == []
+
+    def test_single_tool(self):
+        """Single tool should get cache_control."""
+        tools = [{"name": "test", "description": "Test tool"}]
+        result = build_cached_tool_definitions(tools)
+
+        assert len(result) == 1
+        assert result[0]["name"] == "test"
+        assert "cache_control" in result[0]
+        assert result[0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_multiple_tools_only_last_cached(self):
+        """Only last tool in list should have cache_control."""
+        tools = [
+            {"name": "tool1", "description": "First"},
+            {"name": "tool2", "description": "Second"},
+            {"name": "tool3", "description": "Third"},
+        ]
+        result = build_cached_tool_definitions(tools)
+
+        assert len(result) == 3
+        assert "cache_control" not in result[0]
+        assert "cache_control" not in result[1]
+        assert "cache_control" in result[2]
+
+    def test_does_not_mutate_original(self):
+        """Should not mutate original tools list."""
+        original_tool = {"name": "test", "description": "Test"}
+        tools = [original_tool]
+        build_cached_tool_definitions(tools)
+
+        assert "cache_control" not in original_tool
+
+
+class TestEstimateCacheTokens:
+    """Tests for estimate_cache_tokens function."""
+
+    def test_empty_string(self):
+        """Empty string should return 0."""
+        assert estimate_cache_tokens("") == 0
+
+    def test_short_text(self):
+        """Short text should return proportional estimate."""
+        # ~4 chars per token
+        result = estimate_cache_tokens("test")
+        assert result == 1
+
+    def test_longer_text(self):
+        """Longer text should scale proportionally."""
+        text = "a" * 4000  # ~1000 tokens
+        result = estimate_cache_tokens(text)
+        assert 900 <= result <= 1100  # Allow some variance
+
+
+class TestIsCacheable:
+    """Tests for is_cacheable function."""
+
+    def test_short_text_not_cacheable(self):
+        """Short text should not be cacheable."""
+        result = is_cacheable("Short text")
+        assert result is False
+
+    def test_long_text_cacheable(self):
+        """Text with 1024+ tokens should be cacheable."""
+        # Create text with ~1100 tokens (4400 chars)
+        text = "a" * 4400
+        result = is_cacheable(text)
+        assert result is True
+
+    def test_custom_threshold(self):
+        """Custom threshold should be respected."""
+        text = "a" * 400  # ~100 tokens
+        assert is_cacheable(text, min_tokens=50) is True
+        assert is_cacheable(text, min_tokens=200) is False
+
+    def test_boundary_case(self):
+        """Test near the boundary."""
+        # 4096 chars = ~1024 tokens
+        text = "a" * 4096
+        result = is_cacheable(text)
+        assert result is True


### PR DESCRIPTION
## Summary

- Implements Claude's prompt caching feature to dramatically reduce costs for repeated system prompts
- Adds `cache_control` breakpoints to system prompts and tool definitions
- Creates CacheMetrics tracking for hit rates and cost savings estimation
- Integrates cache metrics with Langfuse observability for monitoring
- Targets 80%+ cache hit rate and 50%+ cost reduction for typical workflows

## Implementation Details

### New `src/caching/` Module
- `prompt_cache.py`: Core utilities for building cached prompts
  - `CacheControl` and `CacheableContent` dataclasses
  - `CachedPromptBuilder` for constructing prompts with optimal cache placement
  - `build_cached_system_prompt()` convenience function
  - `build_cached_tool_definitions()` for tool caching
- `metrics.py`: Cache metrics tracking
  - `CacheMetrics` for per-call tracking (hit rate, savings %)
  - `CacheMetricsCollector` for aggregating across workflow
- `observability.py`: Langfuse integration
  - `CacheObservabilityReporter` for reporting cache performance
  - Alerts for low cache hit rates

### Updated `src/agents/base.py`
- Added `enable_cache` parameter (defaults to `settings.USE_PROMPT_CACHING`)
- Modified `_call_llm` to use cached prompt structure when enabled
- Added `last_cache_metrics` attribute for tracking

### New `src/config.py`
- Settings module with `USE_PROMPT_CACHING` flag (default: True)

## Test Plan
- [x] Comprehensive tests for prompt caching utilities (77 tests)
- [x] Tests for cache metrics tracking
- [x] Tests for observability integration
- [x] Tests for base agent caching behavior
- [x] All 1419 tests passing
- [x] Linting passes

## References
- Closes #79
- [Anthropic Prompt Caching Documentation](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)